### PR TITLE
Add buildPinocchioModelfromiDynTree function to load pinocchio model from iDynTree::Model

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ set_target_properties(iDynFor PROPERTIES VERSION ${${PROJECT_NAME}_VERSION}
 target_include_directories(iDynFor PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
                                           "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
 
-target_link_libraries(iDynFor PUBLIC Eigen3::Eigen pinocchio::pinocchio iDynTree::idyntree-core)
+target_link_libraries(iDynFor PUBLIC Eigen3::Eigen pinocchio::pinocchio iDynTree::idyntree-core  iDynTree::idyntree-model)
 
 # Workaround for https://github.com/ami-iit/idynfor/issues/10
 if(WIN32)

--- a/src/iDynFor/iDynTreePinocchioConversions.h
+++ b/src/iDynFor/iDynTreePinocchioConversions.h
@@ -21,7 +21,7 @@ namespace details
 // All this part is taken from https://github.com/stack-of-tasks/pinocchio/blob/v2.6.8/src/parsers/urdf/model.hxx
 // Unfortunatly, it is not public, so it can't be reused
 template<typename _Scalar, int Options>
-class iDynTreeVisitorBaseTpl {
+class iDynTreeModelVisitorBaseTpl {
   public:
     enum JointType {
       REVOLUTE, CONTINUOUS, PRISMATIC, FLOATING, PLANAR
@@ -41,9 +41,9 @@ class iDynTreeVisitorBaseTpl {
         const std::string & joint_name,
         const pinocchio::Inertia& Y,
         const std::string & body_name) = 0;
-    iDynTreeVisitorBaseTpl () : log (NULL) {}
+    iDynTreeModelVisitorBaseTpl () : log (NULL) {}
     template <typename T>
-    iDynTreeVisitorBaseTpl& operator<< (const T& t)
+    iDynTreeModelVisitorBaseTpl& operator<< (const T& t)
     {
       if (log != NULL) *log << t;
       return *this;
@@ -52,10 +52,10 @@ class iDynTreeVisitorBaseTpl {
 };
 
 template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
-class iDynTreeVisitor : public iDynTreeVisitorBaseTpl<Scalar, Options>
+class iDynTreeModelVisitor : public iDynTreeModelVisitorBaseTpl<Scalar, Options>
 {
   public:
-    typedef iDynTreeVisitorBaseTpl<Scalar, Options> Base;
+    typedef iDynTreeModelVisitorBaseTpl<Scalar, Options> Base;
     typedef typename Base::JointType      JointType;
     typedef typename Base::Vector3        Vector3;
     typedef typename Base::VectorConstRef VectorConstRef;
@@ -63,7 +63,7 @@ class iDynTreeVisitor : public iDynTreeVisitorBaseTpl<Scalar, Options>
     typedef typename Base::Inertia        Inertia;
     typedef pinocchio::ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     Model& model;
-    iDynTreeVisitor (Model& model) : model(model) {}
+    iDynTreeModelVisitor (Model& model) : model(model) {}
     void setName (const std::string& name)
     {
       model.name = name;
@@ -95,7 +95,7 @@ class iDynTreeVisitor : public iDynTreeVisitorBaseTpl<Scalar, Options>
 
 };
 
-typedef iDynTreeVisitorBaseTpl<double, 0> iDynTreeVisitorBase;
+typedef iDynTreeModelVisitorBaseTpl<double, 0> iDynTreeModelVisitorBase;
 }
 
 
@@ -127,7 +127,7 @@ buildModelfromiDynTree(const iDynTree::Model & modelIDynTree,
     }
 
     // Build visitior 
-    iDynFor::details::iDynTreeVisitor<Scalar, Options, JointCollectionTpl> visitor(modelPin);
+    iDynFor::details::iDynTreeModelVisitor<Scalar, Options, JointCollectionTpl> visitor(modelPin);
 
     // Once iDynTree::Model has a name pass the name along
     // See https://github.com/robotology/idyntree/issues/908

--- a/src/iDynFor/iDynTreePinocchioConversions.h
+++ b/src/iDynFor/iDynTreePinocchioConversions.h
@@ -116,9 +116,9 @@ pinocchio::Inertia toPinocchio(const iDynTree::SpatialInertia& inertiaIDynTree);
  */
 template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
 pinocchio::ModelTpl<Scalar,Options,JointCollectionTpl> &
-buildModelfromiDynTree(const iDynTree::Model & modelIDynTree,
-                       pinocchio::ModelTpl<Scalar,Options,JointCollectionTpl> & modelPin,
-                       const bool verbose = false)
+buildPinocchioModelfromiDynTree(const iDynTree::Model & modelIDynTree,
+                                pinocchio::ModelTpl<Scalar,Options,JointCollectionTpl> & modelPin,
+                                const bool verbose = false)
 {
     if (modelIDynTree.getNrOfLinks() > 1)
     {

--- a/src/iDynFor/iDynTreePinocchioConversions.h
+++ b/src/iDynFor/iDynTreePinocchioConversions.h
@@ -4,14 +4,143 @@
  */
 
 // pinocchio
+#include <pinocchio/fwd.hpp>
+#include <pinocchio/algorithm/frames.hpp>
+#include <pinocchio/multibody/fwd.hpp>
 #include <pinocchio/spatial/inertia.hpp>
 
 // iDynTree 
 #include <iDynTree/Core/SpatialInertia.h>
+#include <iDynTree/Model/Model.h>
 
 namespace iDynFor
 {
+namespace details
+{
 
+// All this part is taken from https://github.com/stack-of-tasks/pinocchio/blob/v2.6.8/src/parsers/urdf/model.hxx
+// Unfortunatly, it is not public, so it can't be reused
+template<typename _Scalar, int Options>
+class iDynTreeVisitorBaseTpl {
+  public:
+    enum JointType {
+      REVOLUTE, CONTINUOUS, PRISMATIC, FLOATING, PLANAR
+    };
+    typedef _Scalar Scalar;
+    typedef pinocchio::SE3Tpl<Scalar,Options> SE3;
+    typedef pinocchio::InertiaTpl<Scalar,Options> Inertia;
+    typedef Eigen::Matrix<Scalar, 3, 1> Vector3;
+    typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
+    typedef Eigen::Ref<Vector> VectorRef;
+    typedef Eigen::Ref<const Vector> VectorConstRef;
+    virtual void setName (const std::string& name) = 0;
+    virtual void addRootJoint (const Inertia& Y, const std::string & body_name) = 0;
+    virtual void addFixedJointAndBody(
+        const pinocchio::FrameIndex & parentFrameId,
+        const pinocchio::SE3 & joint_placement,
+        const std::string & joint_name,
+        const pinocchio::Inertia& Y,
+        const std::string & body_name) = 0;
+    iDynTreeVisitorBaseTpl () : log (NULL) {}
+    template <typename T>
+    iDynTreeVisitorBaseTpl& operator<< (const T& t)
+    {
+      if (log != NULL) *log << t;
+      return *this;
+    }
+    std::ostream* log;
+};
+
+template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+class iDynTreeVisitor : public iDynTreeVisitorBaseTpl<Scalar, Options>
+{
+  public:
+    typedef iDynTreeVisitorBaseTpl<Scalar, Options> Base;
+    typedef typename Base::JointType      JointType;
+    typedef typename Base::Vector3        Vector3;
+    typedef typename Base::VectorConstRef VectorConstRef;
+    typedef typename Base::SE3            SE3;
+    typedef typename Base::Inertia        Inertia;
+    typedef pinocchio::ModelTpl<Scalar,Options,JointCollectionTpl> Model;
+    Model& model;
+    iDynTreeVisitor (Model& model) : model(model) {}
+    void setName (const std::string& name)
+    {
+      model.name = name;
+    }
+    virtual void addRootJoint(const Inertia& Y, const std::string & body_name)
+    {
+        addFixedJointAndBody(0, SE3::Identity(), "root_joint", Y, body_name);
+        // TODO: change for the correct behavior, see 
+        //   https://github.com/stack-of-tasks/pinocchio/pull/1102 for discussions on the topic
+        //   and https://github.com/stack-of-tasks/pinocchio/blob/280005c8d99c2485ee942b6a38c4dc0edf75c706/src/parsers/urdf/model.hxx#L117
+        // appendBodyToJoint(0,Y,SE3::Identity(),body_name); 
+    }
+    virtual void addFixedJointAndBody(
+        const pinocchio::FrameIndex & parent_frame_id,
+        const pinocchio::SE3 & joint_placement,
+        const std::string & joint_name,
+        const pinocchio::Inertia & Y,
+        const std::string & body_name)
+    {
+        const pinocchio::Frame & parent_frame = model.frames[parent_frame_id];
+        const pinocchio::JointIndex parent_frame_parent = parent_frame.parent;
+
+        const pinocchio::SE3 placement = parent_frame.placement * joint_placement;
+        pinocchio::FrameIndex fid = model.addFrame(pinocchio::Frame(joint_name, parent_frame.parent, parent_frame_id,
+                                            placement, pinocchio::FIXED_JOINT, Y));
+
+        model.addBodyFrame(body_name, parent_frame_parent, placement, (int)fid);
+    }
+
+};
+
+typedef iDynTreeVisitorBaseTpl<double, 0> iDynTreeVisitorBase;
+}
+
+
+/**
+ * Convert an iDynTree::SpatialInertia to a pinocchio::Inertia
+ */
 pinocchio::Inertia toPinocchio(const iDynTree::SpatialInertia& inertiaIDynTree);
+
+/**
+ * \brief Build the pinocchio model from a iDynTree::Model .
+ *
+ * \param[in] model The iDynTree::Model to load.
+ * \param[in] verbose Print parsing info.
+ * \param[out] model Reference model where to put the parsed information.
+ * \return Return the reference on argument model for convenience.
+ *
+ * The signature of this function is inspired from the pinocchio::buildModel function
+ */
+template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+pinocchio::ModelTpl<Scalar,Options,JointCollectionTpl> &
+buildModelfromiDynTree(const iDynTree::Model & modelIDynTree,
+                       pinocchio::ModelTpl<Scalar,Options,JointCollectionTpl> & modelPin,
+                       const bool verbose = false)
+{
+    if (modelIDynTree.getNrOfLinks() > 1)
+    {
+        const std::string exception_message("iDynTree::Model has more than one link, only one link models are supported for now.");
+        throw std::invalid_argument(exception_message);
+    }
+
+    // Build visitior 
+    iDynFor::details::iDynTreeVisitor<Scalar, Options, JointCollectionTpl> visitor(modelPin);
+
+    // Once iDynTree::Model has a name pass the name along
+    // See https://github.com/robotology/idyntree/issues/908
+    visitor.setName("iDynForModel");
+
+    // Extract root link from iDynTree
+    iDynTree::LinkConstPtr defaultBaseLink = modelIDynTree.getLink(modelIDynTree.getDefaultBaseLink());
+    std::string defaultBaseLinkName = modelIDynTree.getLinkName(modelIDynTree.getDefaultBaseLink());
+
+    // Add root link
+    visitor.addRootJoint(toPinocchio(defaultBaseLink->getInertia()), defaultBaseLinkName);
+
+    return modelPin;
+}
 
 }

--- a/test/iDynTreePinocchioConversionsTest.cpp
+++ b/test/iDynTreePinocchioConversionsTest.cpp
@@ -45,7 +45,7 @@ TEST_CASE("toPinocchio::iDynTree::SpatialInertia")
 }
 
 
-TEST_CASE("buildModelfromiDynTree")
+TEST_CASE("buildPinocchioModelfromiDynTree")
 {
     // Seed the random generator used by iDynTree
     srand(0);
@@ -55,7 +55,7 @@ TEST_CASE("buildModelfromiDynTree")
         iDynTree::Model idynmodel = iDynTree::getRandomModel(0);
         pinocchio::Model pinmodel;
         bool verbose = true;
-        iDynFor::buildModelfromiDynTree(idynmodel, pinmodel, verbose);
+        iDynFor::buildPinocchioModelfromiDynTree(idynmodel, pinmodel, verbose);
 
         REQUIRE(pinmodel.nbodies == idynmodel.getNrOfLinks());
         REQUIRE(pinmodel.existBodyName(idynmodel.getLinkName(idynmodel.getDefaultBaseLink())));

--- a/test/iDynTreePinocchioConversionsTest.cpp
+++ b/test/iDynTreePinocchioConversionsTest.cpp
@@ -5,11 +5,12 @@
 
 // Catch2
 #include <catch2/catch_test_macros.hpp>
-
+#include <pinocchio/algorithm/model.hpp>
 #include <iDynFor/iDynTreePinocchioConversions.h>
 
 #include <iDynTree/Core/EigenHelpers.h>
 #include <iDynTree/Core/TestUtils.h>
+#include <iDynTree/Model/ModelTestUtils.h>
 
 // The serialization used by iDynTree and the one used by Pinocchio are different:
 // iDynTree: m mc_x mc_y mc_z I_xx I_xy I_xz I_yy I_yz I_zz
@@ -41,5 +42,34 @@ TEST_CASE("toPinocchio::iDynTree::SpatialInertia")
             linkDynamicParametersFromPinocchioToiDynTreeSerialization(pin_inertia_param);
         REQUIRE(idyn_inertia_param.isApprox(pin_inertia_param_idyn_serialization));
     }
+}
+
+
+TEST_CASE("buildModelfromiDynTree")
+{
+    // Seed the random generator used by iDynTree
+    srand(0);
+
+    for(size_t i=0; i < 10; i++) {
+        // For now just support 0-joint models
+        iDynTree::Model idynmodel = iDynTree::getRandomModel(0);
+        pinocchio::Model pinmodel;
+        bool verbose = true;
+        iDynFor::buildModelfromiDynTree(idynmodel, pinmodel, verbose);
+
+        REQUIRE(pinmodel.nbodies == idynmodel.getNrOfLinks());
+        REQUIRE(pinmodel.existBodyName(idynmodel.getLinkName(idynmodel.getDefaultBaseLink())));
+
+        // Verify that the inertia of the models match
+        iDynTree::SpatialInertia idyn_inertia = idynmodel.getLink(idynmodel.getDefaultBaseLink())->getInertia();
+        pinocchio::Inertia pin_inertia = pinmodel.inertias[0];
+
+        Eigen::Matrix<double,10,1> idyn_inertia_param = iDynTree::toEigen(idyn_inertia.asVector());
+        Eigen::Matrix<double,10,1> pin_inertia_param = pin_inertia.toDynamicParameters();
+        Eigen::Matrix<double,10,1> pin_inertia_param_idyn_serialization =
+            linkDynamicParametersFromPinocchioToiDynTreeSerialization(pin_inertia_param);
+        REQUIRE(idyn_inertia_param.isApprox(pin_inertia_param_idyn_serialization));
+    }
 
 }
+


### PR DESCRIPTION
As a first instance, we just support models composed by a single link.

Implementation details:
* For now `buildPinocchioModelfromiDynTree` is templated, so all the helpers method are defined in the headers, this may need to be revised in future PRs
* To be consistent with pinocchio and differently from iDynTree, errors are reported via exception. This can be revised in the future, but basically I tought that as we then want to write bindings compatible with pinocchio, use exception as well may be a good idea.