### PR TITLE
Fix Windows CI pinning eigenpy to 2.7.7

### DIFF
--- a/.github/workflows/conda-forge-ci.yaml
+++ b/.github/workflows/conda-forge-ci.yaml
@@ -31,7 +31,7 @@ jobs:
     - name: Dependencies
       shell: bash -l {0}
       run: |
-        mamba install cmake compilers make ninja pkg-config idyntree pinocchio catch2
+        mamba install cmake compilers make ninja pkg-config idyntree pinocchio catch2 eigenpy=2.7.7
 
     - name: Dependencies [Linux]
       if: contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
Workaround for https://github.com/ami-iit/idynfor/issues/13 and https://github.com/conda-forge/eigenpy-feedstock/issues/87 . A proper  fix is arriving, as mentioned in https://github.com/conda-forge/eigenpy-feedstock/issues/87#issuecomment-1194631740 .