### PR TITLE
Implement iDynFor::KinematicsComputationTpl::getWorldTransform using pinocchio::forwardKinematics

### DIFF
--- a/doc/theory_background.md
+++ b/doc/theory_background.md
@@ -1,7 +1,7 @@
 # iDynFor theory background
 
 This document provide an overview of the different semantics between iDynTree and Pinocchio
-data-structures and interfaces, and provide a reference for the implentation in iDynFor classes, that implements iDynTree-inspired interfaces using Pinocchio.
+data-structures and interfaces, and provide a reference for the implementation in iDynFor classes, that implements iDynTree-inspired interfaces using Pinocchio.
 
 ## iDynTree::Model vs pinocchio::Model
 

--- a/doc/theory_background.md
+++ b/doc/theory_background.md
@@ -1,0 +1,55 @@
+# iDynFor theory background
+
+This document provide an overview of the different semantics between iDynTree and Pinocchio
+data-structures and interfaces, and provide a reference for the implentation in iDynFor classes, that implements iDynTree-inspired interfaces using Pinocchio.
+
+## iDynTree::Model vs pinocchio::Model
+
+### Link and Joints
+
+In `iDynTree::Model` a multibody is composed by its links that are interconnected by joints.
+Each link is connected to another link by a joint, so you can't attach a joint to another joint
+without having a link in the middle. Furthermore, `iDynTree::Model` consider all models to be
+floating base by default, so there is no "joint" connecting the base to "universe" or "world" frame. Only links have a frame w.r.t. to which you can compute forward kinematics or the jacobian, while there is no explicit concept of "joint frame"
+
+On the other hand, in `pinocchio::Model` joints are interconnected to each other, to build
+the so-called "kinematic tree". So multiple joints can be connected to each other, without having a body in the middle. On the other hand, each link must have a parent joint, even if it is the first body of the kinematic tree.
+A model can be connected to the "universe" reference frame with any kind of frame, but for consistency with `iDynTree` the pinocchio models built in `iDynFor` are always connected to "universe" with a `pinocchio::JointFreeFlyer` (i.e. 6-DOF joint).
+
+For these reasons, the count of links and joints in `iDynTree::Model` and  `pinocchio::Model` are differents.
+For links, in iDynTree only the internal bodies that compose the multibody model are counted, while for `pinocchio` also the `universe` "link" is considered.
+For joints, in iDynTree only the joints that internconnect internal links are considered, while in `pinocchio` two additional joints are considerd:
+* the joint that connects the floating base to `universe`,
+* the  parent joint of `universe`.
+
+We will always have that for corresponding models:
+* `iDynTree::Model::getNrOfLinks() + 1 == pinocchio::Model::nbodies` and
+* `iDynTree::Model::getNrOfJoints() + 2 == pinocchio::Model::njoints`.
+
+As an example, if you have a single link floating base model, this is the number of its joints and links w.r.t. if modeled used `iDynTree::Model` and  `pinocchio::Model`:
+
+| Quantity |  `iDynTree::Model`  | `pinocchio::Model` |
+|:--------:|:---------------------:|:--------------------:|
+| Number of Links | 1             |          2            |
+| Number of Joints | 0             |         2            |
+
+### Model Position
+
+**Note: as of iDynTree 8.1.0, iDynTree only supports internal joints of type revolute or prismatic, so
+in this documentation we will always consider the case in which the  derivative of internal shape of the multibody model is used to represent the internal velocity of the multibody model, even if in theory
+the Joint interface used by iDynTree could also support joints in which it may be convenient to use
+as velocity a quantity different from the derivative of the joint position, such as spherical joints.**
+
+In `iDynTree` the model position is represented by a pair of quantities:
+* ${}^A H_B \in SE(3)$, i.e. the homogeneous transform between the base link frame ($B$) and the universe/world "absolute" frame ($A$),
+* $s \in \mathbb{R}^{dof}$, i.e. vector of internal position, also called "shape" (hence the "s") of the multibody model.
+
+In `pinocchio`, the model position is represented by a single quantity:
+* $q \in \mathbb{R}^{nq}$, i.e. the vector of position of all joints, including the joint connecting the base to the "universe" frame. The first 7 elements are the position of the joint connecting the base to the "universe" frame, with the first 3 elements being the ${}^A o_B$, and the other 4 elements a quaternion
+corresponding to ${}^A R_B$, see https://github.com/stack-of-tasks/pinocchio/issues/65#issuecomment-160931189 .
+
+To convert from the `iDynTree` representation to the `pinocchio` one, one needs to convert the ${}^A H_B$ to the first 7 elements of $q$, and then convert $s$ to the last $dof=nq-7$ elements of $q$, accounting for the fact that the ordering used in iDynTree and in pinocchio is different.
+
+
+
+

--- a/doc/theory_background.md
+++ b/doc/theory_background.md
@@ -10,13 +10,17 @@ data-structures and interfaces, and provide a reference for the implementation i
 In `iDynTree::Model` a multibody is composed by its links that are interconnected by joints.
 Each link is connected to another link by a joint, so you can't attach a joint to another joint
 without having a link in the middle. Furthermore, `iDynTree::Model` consider all models to be
-floating base by default, so there is no "joint" connecting the base to "universe" or "world" frame. Only links have a frame w.r.t. to which you can compute forward kinematics or the jacobian, while there is no explicit concept of "joint frame"
+floating base by default, so there is no "joint" connecting the base to "universe" or "world" frame. 
+Only links have a frame w.r.t. to which you can compute forward kinematics or the jacobian, while there is no explicit concept of "joint frame"
 
 On the other hand, in `pinocchio::Model` joints are interconnected to each other, to build
-the so-called "kinematic tree". So multiple joints can be connected to each other, without having a body in the middle. On the other hand, each link must have a parent joint, even if it is the first body of the kinematic tree.
-A model can be connected to the "universe" reference frame with any kind of frame, but for consistency with `iDynTree` the pinocchio models built in `iDynFor` are always connected to "universe" with a `pinocchio::JointFreeFlyer` (i.e. 6-DOF joint).
+the so-called "kinematic tree". So multiple joints can be connected to each other, without having 
+a body in the middle. Furthermore, each link must have a parent joint, even if it is the first body of the kinematic tree.
+So, an empty pinocchio model contains always the `universe` link, and the parent joint of the `universe` link.
+The rest of the model can be connected to the `universe` reference frame with any kind of frame, but for consistency 
+with `iDynTree` the pinocchio models built in `iDynFor` are always connected to "universe" with a `pinocchio::JointFreeFlyer` (i.e. 6-DOF joint).
 
-For these reasons, the count of links and joints in `iDynTree::Model` and  `pinocchio::Model` are differents.
+For these reasons, the count of links and joints in `iDynTree::Model` and  `pinocchio::Model` are different.
 For links, in iDynTree only the internal bodies that compose the multibody model are counted, while for `pinocchio` also the `universe` "link" is considered.
 For joints, in iDynTree only the joints that internconnect internal links are considered, while in `pinocchio` two additional joints are considerd:
 * the joint that connects the floating base to `universe`,

--- a/src/iDynFor/KinDynComputations.h
+++ b/src/iDynFor/KinDynComputations.h
@@ -40,14 +40,21 @@ public:
     typedef Eigen::Matrix<Scalar, 3, 1, Options> Vector3s;
     typedef Eigen::Matrix<Scalar, 6, 1, Options> Vector6s;
 
-private:
-    iDynTree::Model m_idyntreeModel;
-    pinocchio::ModelTpl<Scalar, Options, JointCollectionTpl> m_pinModel;
 
-    // Internal State
+private:
+    // Internal Class State
+
+    // iDynTree model
+    iDynTree::Model m_idyntreeModel;
+    // Pinocchio model
+    pinocchio::ModelTpl<Scalar, Options, JointCollectionTpl> m_pinModel;
+    // Pinocchio data
+    pinocchio::DataTpl<Scalar, Options, JointCollectionTpl> m_pinData;
+
     bool m_modelLoaded = false;
 
-    // State
+    // MultiBody Model State (iDynTree-formalism)
+
     // A: absolute/world frame
     // B: base frame
     // Base Position: {}^A H_B
@@ -61,8 +68,24 @@ private:
     // Gravity expressed in absolute frame: {}^A g
     Vector3s m_world_gravity;
 
-public:
+    // MultiBody Model State (pinocchio-formalism)
 
+    // Base and internal joint position (q)
+    VectorXs m_pin_model_position;
+
+    // Cache-related flags methods
+    bool m_isFwdKinematicsUpdated = false;
+
+    // Invalidate the cache of intermediate results (called by setRobotState)
+    void invalidateCache();
+
+    // Compute forward kinematics, if required
+    void computeFwdKinematics();
+
+    // Convert model state from iDynTree formalism to pinocchio formalism
+    void convertModelStateFromiDynTreeToPinocchio();
+
+public:
     /**
      * Constructor.
      */

--- a/src/iDynFor/KinDynComputations.tpp
+++ b/src/iDynFor/KinDynComputations.tpp
@@ -77,7 +77,8 @@ inline bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::loadRobo
     m_pinData = pinocchio::DataTpl<Scalar, Options, JointCollectionTpl>(m_pinModel);
 
     // Resize m_pin_model_position to right size
-    m_pin_model_position = pinocchio::randomConfiguration(m_pinModel);
+    m_pin_model_position.resize(m_pinModel.nq);
+    m_pin_model_position.setZero();
 
     return (m_modelLoaded = true);
 }

--- a/src/iDynFor/KinDynComputations.tpp
+++ b/src/iDynFor/KinDynComputations.tpp
@@ -7,8 +7,59 @@
 
 #include <iDynTree/Core/Utils.h>
 
+#include "pinocchio/algorithm/joint-configuration.hpp"
+
 namespace iDynFor
 {
+
+// Internal functions methods
+
+template <typename Scalar, int Options, template <typename, int> class JointCollectionTpl>
+void KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::invalidateCache()
+{
+    m_isFwdKinematicsUpdated = false;
+}
+
+template <typename Scalar, int Options, template <typename, int> class JointCollectionTpl>
+void KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::computeFwdKinematics()
+{
+    if( this->m_isFwdKinematicsUpdated )
+    {
+        return;
+    }
+
+    this->convertModelStateFromiDynTreeToPinocchio();
+
+    // Compute position and velocity kinematics
+    // TODO(traversaro): Swich to the four-parameters variant when we add support for velocities
+    pinocchio::forwardKinematics(m_pinModel, m_pinData, m_pin_model_position);
+
+    this->m_isFwdKinematicsUpdated = true;
+}
+
+template <typename Scalar, int Options, template <typename, int> class JointCollectionTpl>
+void KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::convertModelStateFromiDynTreeToPinocchio()
+{
+    typedef Eigen::Matrix<Scalar, 4, 1, Options> Vector4s;
+    typedef Eigen::Quaternion<Scalar, Options> Quaternions;
+
+    // Position
+    // The initial three elements of the pinocchio q vector are the origin of the base frame
+    // w.r.t. to the world frame, i.e. {}^A o_B \in \mathbb{R}^3
+    m_pin_model_position.block(0,0,3,1) = m_world_H_base.translation();
+
+    // The next four elements are the quaternion corresponding to the {}^A R_B \in SO(3) orientation
+    // As the quaternion's coeffs method is used by pinocchio, pay attention that the order is (imaginary, real)
+    Quaternions quaternion(m_world_H_base.rotation());
+    m_pin_model_position.block(3,0,4,1) = Eigen::Map<Vector4s>(quaternion.coeffs().data());
+
+    // The rest of the elements are the position of the internal joints, accounting for the
+    // difference in position coordinate serialization between iDynTree and Pinocchio
+    // TODO(traversaro) : handle this
+
+    return;
+}
+
 
 template <typename Scalar, int Options, template <typename, int> class JointCollectionTpl>
 inline bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::loadRobotModel(
@@ -22,6 +73,11 @@ inline bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::loadRobo
     iDynFor::buildPinocchioModelfromiDynTree<Scalar, Options, JointCollectionTpl>(m_idyntreeModel,
                                                                                   m_pinModel,
                                                                                   verbose);
+
+    m_pinData = pinocchio::DataTpl<Scalar, Options, JointCollectionTpl>(m_pinModel);
+
+    // Resize m_pin_model_position to right size
+    m_pin_model_position = pinocchio::randomConfiguration(m_pinModel);
 
     return (m_modelLoaded = true);
 }
@@ -53,8 +109,7 @@ bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::setRobotState(
     const VectorXs& joint_vel,
     const Vector3s& world_gravity)
 {
-    // TODO(traversaro): call as soon as it is implemented
-    // this->invalidateCache();
+    this->invalidateCache();
 
     // Save pos
     m_world_H_base = world_H_base;
@@ -95,7 +150,23 @@ bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::getWorldTransfo
     iDynTree::reportErrorIf(frameIndex != 0,
                             "iDynFor::KinDynComputationsTpl::getWorldTransform",
                             "requested frame not supported");
-    world_H_frame = m_world_H_base;
+
+    this->computeFwdKinematics();
+
+    // Convert iDynTree::FrameIndex to pinocchio::FrameIndex
+    // TODO(traversaro): also support additional frames, not only frames associated to a link
+    // TODO(traversaro): cache this information, there is no need to do a string search every time
+    pinocchio::FrameIndex pinFrameIndex = m_pinModel.getFrameId(m_idyntreeModel.getFrameName(frameIndex));
+
+    // After computeFwdKinematics computed the forwardKinematics, in m_pinData it is
+    // store the universe_H_<..> transform for each joint frame
+    // From the iDynTree-point of view, we are interested only in the universe_H_<..>
+    // transforms of link frames and additional frames, so we compute the one request
+    // See https://github.com/stack-of-tasks/pinocchio/issues/802#issuecomment-496210616
+    // TODO(traversaro): understand if it is worth to cache also this
+    pinocchio::updateFramePlacement(m_pinModel, m_pinData, pinFrameIndex);
+    world_H_frame = m_pinData.oMf[pinFrameIndex];
+
     return true;
 }
 

--- a/src/iDynFor/KinDynComputations.tpp
+++ b/src/iDynFor/KinDynComputations.tpp
@@ -7,7 +7,7 @@
 
 #include <iDynTree/Core/Utils.h>
 
-#include "pinocchio/algorithm/joint-configuration.hpp"
+#include <pinocchio/algorithm/joint-configuration.hpp>
 
 namespace iDynFor
 {

--- a/src/iDynFor/iDynTreePinocchioConversions.h
+++ b/src/iDynFor/iDynTreePinocchioConversions.h
@@ -91,7 +91,7 @@ public:
       const pinocchio::Frame & frame = model.frames[fid];
       const SE3 & p = frame.placement * placement;
       model.appendBodyToJoint(frame.parent, Y, p);
-      model.addBodyFrame(body_name, frame.parent, p, (int)fid);
+      model.addBodyFrame(body_name, frame.parent, p, static_cast<int>(fid));
 
       // Reference to model.frames[fid] have changed because the vector
       // may have been reallocated.

--- a/test/KinDynComputationsTest.cpp
+++ b/test/KinDynComputationsTest.cpp
@@ -76,8 +76,6 @@ TEST_CASE("KinDynComputations")
                     kinDynFor.getWorldTransform(randomFrameIndex).asHomogeneousTransform());
                 Eigen::Matrix4d worldTransformTree = iDynTree::toEigen(
                     kinDynTree.getWorldTransform(randomFrameIndex).asHomogeneousTransform());
-                std::cerr << "worldTransformFor: " << worldTransformFor << std::endl;
-                std::cerr << "worldTransformTree: " << worldTransformTree << std::endl;
 
                 REQUIRE(worldTransformFor.isApprox(worldTransformTree));
             }

--- a/test/iDynTreePinocchioConversionsTest.cpp
+++ b/test/iDynTreePinocchioConversionsTest.cpp
@@ -47,6 +47,51 @@ TEST_CASE("toPinocchio::iDynTree::SpatialInertia")
     }
 }
 
+std::string fromPinocchioFrameTypeToString(const pinocchio::FrameType& in)
+{
+    switch(in) {
+        case pinocchio::FrameType::OP_FRAME:
+            return "OP_FRAME";
+        case pinocchio::FrameType::JOINT:
+            return "JOINT";
+        case pinocchio::FrameType::FIXED_JOINT:
+            return "FIXED_JOINT";
+        case pinocchio::FrameType::BODY:
+            return "BODY";
+        case pinocchio::FrameType::SENSOR:
+            return "SENSOR";
+        default:
+            return "UNKNOWN";
+    }
+}
+
+void printPinocchioFrameInfo(const pinocchio::Frame& frame)
+{
+    std::cerr << "frame.name: " << frame.name << std::endl;
+    std::cerr << "frame.parent(joint): " << frame.parent << std::endl;
+    std::cerr << "frame.previousFrame: " << frame.previousFrame << std::endl;
+    std::cerr << "frame.type: " << fromPinocchioFrameTypeToString(frame.type) << std::endl;
+
+}
+
+void printPinocchioModelInfo(const pinocchio::Model& model)
+{
+    std::cerr << "printPinocchioModelInfo" << std::endl;
+    std::cerr << model << std::endl;
+    std::cerr << "model.nbodies: " << model.nbodies << std::endl;
+    std::cerr << "model.njoints: " << model.njoints << std::endl;
+    std::cerr << "model.nframes: " << model.nframes << std::endl;
+    for(auto& frame: model.frames)
+    {
+        printPinocchioFrameInfo(frame);
+    }
+    for(auto& inertia: model.inertias)
+    {
+        std::cerr << "inertia: " << inertia << std::endl;
+    }
+
+}
+
 TEST_CASE("buildPinocchioModelfromiDynTree")
 {
     // Seed the random generator used by iDynTree
@@ -60,20 +105,42 @@ TEST_CASE("buildPinocchioModelfromiDynTree")
         bool verbose = true;
         iDynFor::buildPinocchioModelfromiDynTree(idynmodel, pinmodel, verbose);
 
-        REQUIRE(pinmodel.nbodies == idynmodel.getNrOfLinks());
+        // Uncomment for debug
+        // printPinocchioModelInfo(pinmodel);
+
+        // See doc/theory_background.md for the motivation
+        // In a nutshell, pinocchio consider also the "universe" as
+        // a link and the joint connecting the "universe" and the base as a joint
+        // For joints, two additional joints are considered in pinocchio
+        REQUIRE(idynmodel.getNrOfLinks() + 1 == pinmodel.nbodies);
+        REQUIRE(idynmodel.getNrOfJoints() + 2 == pinmodel.njoints);
+        // iDynTree's getNrOfPosCoords() consider only internal coordinates
+        // so we need to add 7 (3 linear position + 4 quaternion) to match pinocchio
+        REQUIRE(idynmodel.getNrOfPosCoords() + 7 == pinmodel.nq);
+        // iDynTree's getNrOfDOFs() consider only internal coordinates
+        // so we need to add 6 (3 linear velocity + 3 angular velocity) to match pinocchio
+        REQUIRE(idynmodel.getNrOfDOFs() + 6 == pinmodel.nv);
+
         REQUIRE(pinmodel.existBodyName(idynmodel.getLinkName(idynmodel.getDefaultBaseLink())));
 
         // Verify that the inertia of the models match
-        iDynTree::SpatialInertia idyn_inertia
-            = idynmodel.getLink(idynmodel.getDefaultBaseLink())->getInertia();
-        pinocchio::Inertia pin_inertia = pinmodel.inertias[0];
+        for(iDynTree::LinkIndex lnkIdxiDynTree = 0; lnkIdxiDynTree < idynmodel.getNrOfLinks(); lnkIdxiDynTree++)
+        {
+            // In iDynTree, inertia is indexed w.r.t. to LinkIndex, in pinocchio with rispect to the parent
+            // joint of the link with that inertia. So, here we need to find the JointIndex corresponding
+            // to the inertia we are looking for
+            pinocchio::JointIndex lnkIdxPinocchio = pinmodel.frames[pinmodel.getBodyId(idynmodel.getLinkName(lnkIdxiDynTree))].parent;
+            iDynTree::SpatialInertia idyn_inertia
+                = idynmodel.getLink(lnkIdxiDynTree)->getInertia();
+            pinocchio::Inertia pin_inertia = pinmodel.inertias[lnkIdxPinocchio];
 
-        Eigen::Matrix<double, 10, 1> idyn_inertia_param
-            = iDynTree::toEigen(idyn_inertia.asVector());
-        Eigen::Matrix<double, 10, 1> pin_inertia_param = pin_inertia.toDynamicParameters();
-        Eigen::Matrix<double, 10, 1> pin_inertia_param_idyn_serialization
-            = linkDynamicParametersFromPinocchioToiDynTreeSerialization(pin_inertia_param);
-        REQUIRE(idyn_inertia_param.isApprox(pin_inertia_param_idyn_serialization));
+            Eigen::Matrix<double, 10, 1> idyn_inertia_param
+                = iDynTree::toEigen(idyn_inertia.asVector());
+            Eigen::Matrix<double, 10, 1> pin_inertia_param = pin_inertia.toDynamicParameters();
+            Eigen::Matrix<double, 10, 1> pin_inertia_param_idyn_serialization
+                = linkDynamicParametersFromPinocchioToiDynTreeSerialization(pin_inertia_param);
+            REQUIRE(idyn_inertia_param.isApprox(pin_inertia_param_idyn_serialization));
+        }
     }
 }
 
@@ -92,8 +159,8 @@ TEST_CASE("toAndFromPinocchio::iDynTree::Transform")
             = iDynTree::toEigen(idyn_transform.asHomogeneousTransform());
         Eigen::Matrix4d eigen_transform_check
             = iDynTree::toEigen(idyn_transform_via_pin.asHomogeneousTransform());
-        std::cerr << "eigen_transform: " << eigen_transform << std::endl;
-        std::cerr << "eigen_transform_check: " << eigen_transform_check << std::endl;
+        //std::cerr << "eigen_transform: " << eigen_transform << std::endl;
+        //std::cerr << "eigen_transform_check: " << eigen_transform_check << std::endl;
 
         REQUIRE(eigen_transform.isApprox(eigen_transform_check));
     }


### PR DESCRIPTION
Fix https://github.com/ami-iit/idynfor/issues/20 .

With respect to https://github.com/ami-iit/idynfor/pull/19, nothing changed in the high-level behaviour of the classes: the only method supported continues to be just `getWorldTransform` for one-body (and zero additional frames) models. Anyhow, in this PR we start to actually use the pinocchio's `forwardKinematics`, that is necessary to then scale to more complex models. To do so, they were necessary a few fixes:
* The `iDynTree::Model` --> `pinocchio::Model` conversion logic was flawed, as we were converting models that from the pinocchio point of view were welded to the universe (i.e. fixed base) and not floating base as the one assumed by iDynTree. This PR fixes that error, and update the tests to account for this.
* To use `pinocchio::forwardKinematics`, it was necessary to convert from how `iDynTree` represent the model state and how pinocchio represent it. This is handled in the `convertModelStateFromiDynTreeToPinocchio` method. 
* While solving the previous points, I had to understand a bit more the relation between `iDynTree::Model` and `pinocchio::Model`. My finding are documented in `doc/theory_background.md` .

No new tests have been added, as the `getWorldTransform` methods were already tested in  https://github.com/ami-iit/idynfor/pull/19 .