### PR TITLE
Handle additional frames in getWorldTransform

### DIFF
--- a/src/iDynFor/KinDynComputations.tpp
+++ b/src/iDynFor/KinDynComputations.tpp
@@ -146,11 +146,6 @@ template <typename Scalar, int Options, template <typename, int> class JointColl
 bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::getWorldTransform(
     const iDynTree::FrameIndex frameIndex, SE3s& world_H_frame)
 {
-    // TODO: implement frame different from the base one
-    iDynTree::reportErrorIf(frameIndex != 0,
-                            "iDynFor::KinDynComputationsTpl::getWorldTransform",
-                            "requested frame not supported");
-
     this->computeFwdKinematics();
 
     // Convert iDynTree::FrameIndex to pinocchio::FrameIndex

--- a/test/KinDynComputationsTest.cpp
+++ b/test/KinDynComputationsTest.cpp
@@ -19,8 +19,9 @@ TEST_CASE("KinDynComputations")
 
     for (size_t i = 0; i < 10; i++)
     {
-        // For now just support 0-joint models with 0 additional frames
-        iDynTree::Model idynmodel = iDynTree::getRandomModel(0, 0);
+        // For now just support 0-joint models
+        size_t nrOfAdditionalFrames = 10;
+        iDynTree::Model idynmodel = iDynTree::getRandomModel(0, nrOfAdditionalFrames);
 
         // Create both a new and and old KinDynComputations to check consistency
         iDynFor::iDynTreeFullyCompatible::KinDynComputations kinDynFor;
@@ -57,9 +58,6 @@ TEST_CASE("KinDynComputations")
             REQUIRE(
                 kinDynTree.setRobotState(world_H_base, joint_pos, base_vel, joint_vel, gravity));
             REQUIRE(kinDynFor.setRobotState(world_H_base, joint_pos, base_vel, joint_vel, gravity));
-
-            // TODO : remove check when there are other frames
-            REQUIRE(idynmodel.getNrOfFrames() == 1);
 
             // Test frame-related methods
             int nrOfFramesToTest = 3;


### PR DESCRIPTION
Before this PR, only single-body with no additional frames were supported. Now also additional frames are supported. Only the model conversion need to be fix, as the `getWorldTransform`  was already working fine as implemented in https://github.com/ami-iit/idynfor/pull/21 .

Fix https://github.com/ami-iit/idynfor/issues/22 .