### PR TITLE
Reformat with clang-format

### DIFF
--- a/src/iDynFor/KinDynComputations.h
+++ b/src/iDynFor/KinDynComputations.h
@@ -40,7 +40,6 @@ public:
     typedef Eigen::Matrix<Scalar, 3, 1, Options> Vector3s;
     typedef Eigen::Matrix<Scalar, 6, 1, Options> Vector6s;
 
-
 private:
     // Internal Class State
 

--- a/src/iDynFor/KinDynComputations.tpp
+++ b/src/iDynFor/KinDynComputations.tpp
@@ -23,7 +23,7 @@ void KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::invalidateCache
 template <typename Scalar, int Options, template <typename, int> class JointCollectionTpl>
 void KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::computeFwdKinematics()
 {
-    if( this->m_isFwdKinematicsUpdated )
+    if (this->m_isFwdKinematicsUpdated)
     {
         return;
     }
@@ -38,7 +38,8 @@ void KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::computeFwdKinem
 }
 
 template <typename Scalar, int Options, template <typename, int> class JointCollectionTpl>
-void KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::convertModelStateFromiDynTreeToPinocchio()
+void KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::
+    convertModelStateFromiDynTreeToPinocchio()
 {
     typedef Eigen::Matrix<Scalar, 4, 1, Options> Vector4s;
     typedef Eigen::Quaternion<Scalar, Options> Quaternions;
@@ -46,12 +47,13 @@ void KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::convertModelSta
     // Position
     // The initial three elements of the pinocchio q vector are the origin of the base frame
     // w.r.t. to the world frame, i.e. {}^A o_B \in \mathbb{R}^3
-    m_pin_model_position.block(0,0,3,1) = m_world_H_base.translation();
+    m_pin_model_position.block(0, 0, 3, 1) = m_world_H_base.translation();
 
     // The next four elements are the quaternion corresponding to the {}^A R_B \in SO(3) orientation
-    // As the quaternion's coeffs method is used by pinocchio, pay attention that the order is (imaginary, real)
+    // As the quaternion's coeffs method is used by pinocchio, pay attention that the order is
+    // (imaginary, real)
     Quaternions quaternion(m_world_H_base.rotation());
-    m_pin_model_position.block(3,0,4,1) = Eigen::Map<Vector4s>(quaternion.coeffs().data());
+    m_pin_model_position.block(3, 0, 4, 1) = Eigen::Map<Vector4s>(quaternion.coeffs().data());
 
     // The rest of the elements are the position of the internal joints, accounting for the
     // difference in position coordinate serialization between iDynTree and Pinocchio
@@ -59,7 +61,6 @@ void KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::convertModelSta
 
     return;
 }
-
 
 template <typename Scalar, int Options, template <typename, int> class JointCollectionTpl>
 inline bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::loadRobotModel(
@@ -157,7 +158,8 @@ bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::getWorldTransfo
     // Convert iDynTree::FrameIndex to pinocchio::FrameIndex
     // TODO(traversaro): also support additional frames, not only frames associated to a link
     // TODO(traversaro): cache this information, there is no need to do a string search every time
-    pinocchio::FrameIndex pinFrameIndex = m_pinModel.getFrameId(m_idyntreeModel.getFrameName(frameIndex));
+    pinocchio::FrameIndex pinFrameIndex
+        = m_pinModel.getFrameId(m_idyntreeModel.getFrameName(frameIndex));
 
     // After computeFwdKinematics computed the forwardKinematics, in m_pinData it is
     // store the universe_H_<..> transform for each joint frame

--- a/src/iDynFor/iDynTreePinocchioConversions.h
+++ b/src/iDynFor/iDynTreePinocchioConversions.h
@@ -81,34 +81,35 @@ public:
         model.name = name;
     }
 
-    void appendBodyToJoint(
-        const pinocchio::FrameIndex fid,
-        const Inertia& Y,
-        const SE3 & placement,
-        const std::string & body_name)
+    void appendBodyToJoint(const pinocchio::FrameIndex fid,
+                           const Inertia& Y,
+                           const SE3& placement,
+                           const std::string& body_name)
 
     {
-      const pinocchio::Frame & frame = model.frames[fid];
-      const SE3 & p = frame.placement * placement;
-      model.appendBodyToJoint(frame.parent, Y, p);
-      model.addBodyFrame(body_name, frame.parent, p, static_cast<int>(fid));
+        const pinocchio::Frame& frame = model.frames[fid];
+        const SE3& p = frame.placement * placement;
+        model.appendBodyToJoint(frame.parent, Y, p);
+        model.addBodyFrame(body_name, frame.parent, p, static_cast<int>(fid));
 
-      // Reference to model.frames[fid] have changed because the vector
-      // may have been reallocated.
+        // Reference to model.frames[fid] have changed because the vector
+        // may have been reallocated.
     }
 
     virtual void addRootJoint(const Inertia& Y, const std::string& body_name)
     {
-        // Inspired by https://github.com/stack-of-tasks/pinocchio/blob/v2.6.17/src/parsers/urdf/model.hxx#L343
+        // Inspired by
+        // https://github.com/stack-of-tasks/pinocchio/blob/v2.6.17/src/parsers/urdf/model.hxx#L343
         // The main difference is that iDynTree models always assume that the root joint is
         // always the floating one, so we hardcode the pinocchio::JointModelFreeFlyerTpl choice
-        const pinocchio::Frame & frame = model.frames[0];
+        const pinocchio::Frame& frame = model.frames[0];
 
         // We give a name that starts with "idynfor_" to avoid collisions with a model
         // that already contains a joint named "root_joint"
         pinocchio::JointIndex idx = model.addJoint(frame.parent,
-            pinocchio::JointModelFreeFlyer(),
-            SE3::Identity(), "idynfor_root_joint");
+                                                   pinocchio::JointModelFreeFlyer(),
+                                                   SE3::Identity(),
+                                                   "idynfor_root_joint");
 
         pinocchio::FrameIndex jointFrameId = model.addJointFrame(idx, 0);
         appendBodyToJoint(jointFrameId, Y, SE3::Identity(), body_name);

--- a/test/iDynTreePinocchioConversionsTest.cpp
+++ b/test/iDynTreePinocchioConversionsTest.cpp
@@ -49,19 +49,20 @@ TEST_CASE("toPinocchio::iDynTree::SpatialInertia")
 
 std::string fromPinocchioFrameTypeToString(const pinocchio::FrameType& in)
 {
-    switch(in) {
-        case pinocchio::FrameType::OP_FRAME:
-            return "OP_FRAME";
-        case pinocchio::FrameType::JOINT:
-            return "JOINT";
-        case pinocchio::FrameType::FIXED_JOINT:
-            return "FIXED_JOINT";
-        case pinocchio::FrameType::BODY:
-            return "BODY";
-        case pinocchio::FrameType::SENSOR:
-            return "SENSOR";
-        default:
-            return "UNKNOWN";
+    switch (in)
+    {
+    case pinocchio::FrameType::OP_FRAME:
+        return "OP_FRAME";
+    case pinocchio::FrameType::JOINT:
+        return "JOINT";
+    case pinocchio::FrameType::FIXED_JOINT:
+        return "FIXED_JOINT";
+    case pinocchio::FrameType::BODY:
+        return "BODY";
+    case pinocchio::FrameType::SENSOR:
+        return "SENSOR";
+    default:
+        return "UNKNOWN";
     }
 }
 
@@ -71,7 +72,6 @@ void printPinocchioFrameInfo(const pinocchio::Frame& frame)
     std::cerr << "frame.parent(joint): " << frame.parent << std::endl;
     std::cerr << "frame.previousFrame: " << frame.previousFrame << std::endl;
     std::cerr << "frame.type: " << fromPinocchioFrameTypeToString(frame.type) << std::endl;
-
 }
 
 void printPinocchioModelInfo(const pinocchio::Model& model)
@@ -81,15 +81,14 @@ void printPinocchioModelInfo(const pinocchio::Model& model)
     std::cerr << "model.nbodies: " << model.nbodies << std::endl;
     std::cerr << "model.njoints: " << model.njoints << std::endl;
     std::cerr << "model.nframes: " << model.nframes << std::endl;
-    for(auto& frame: model.frames)
+    for (auto& frame : model.frames)
     {
         printPinocchioFrameInfo(frame);
     }
-    for(auto& inertia: model.inertias)
+    for (auto& inertia : model.inertias)
     {
         std::cerr << "inertia: " << inertia << std::endl;
     }
-
 }
 
 TEST_CASE("buildPinocchioModelfromiDynTree")
@@ -124,14 +123,15 @@ TEST_CASE("buildPinocchioModelfromiDynTree")
         REQUIRE(pinmodel.existBodyName(idynmodel.getLinkName(idynmodel.getDefaultBaseLink())));
 
         // Verify that the inertia of the models match
-        for(iDynTree::LinkIndex lnkIdxiDynTree = 0; lnkIdxiDynTree < idynmodel.getNrOfLinks(); lnkIdxiDynTree++)
+        for (iDynTree::LinkIndex lnkIdxiDynTree = 0; lnkIdxiDynTree < idynmodel.getNrOfLinks();
+             lnkIdxiDynTree++)
         {
-            // In iDynTree, inertia is indexed w.r.t. to LinkIndex, in pinocchio with rispect to the parent
-            // joint of the link with that inertia. So, here we need to find the JointIndex corresponding
-            // to the inertia we are looking for
-            pinocchio::JointIndex lnkIdxPinocchio = pinmodel.frames[pinmodel.getBodyId(idynmodel.getLinkName(lnkIdxiDynTree))].parent;
-            iDynTree::SpatialInertia idyn_inertia
-                = idynmodel.getLink(lnkIdxiDynTree)->getInertia();
+            // In iDynTree, inertia is indexed w.r.t. to LinkIndex, in pinocchio with rispect to the
+            // parent joint of the link with that inertia. So, here we need to find the JointIndex
+            // corresponding to the inertia we are looking for
+            pinocchio::JointIndex lnkIdxPinocchio
+                = pinmodel.frames[pinmodel.getBodyId(idynmodel.getLinkName(lnkIdxiDynTree))].parent;
+            iDynTree::SpatialInertia idyn_inertia = idynmodel.getLink(lnkIdxiDynTree)->getInertia();
             pinocchio::Inertia pin_inertia = pinmodel.inertias[lnkIdxPinocchio];
 
             Eigen::Matrix<double, 10, 1> idyn_inertia_param
@@ -159,8 +159,8 @@ TEST_CASE("toAndFromPinocchio::iDynTree::Transform")
             = iDynTree::toEigen(idyn_transform.asHomogeneousTransform());
         Eigen::Matrix4d eigen_transform_check
             = iDynTree::toEigen(idyn_transform_via_pin.asHomogeneousTransform());
-        //std::cerr << "eigen_transform: " << eigen_transform << std::endl;
-        //std::cerr << "eigen_transform_check: " << eigen_transform_check << std::endl;
+        // std::cerr << "eigen_transform: " << eigen_transform << std::endl;
+        // std::cerr << "eigen_transform_check: " << eigen_transform_check << std::endl;
 
         REQUIRE(eigen_transform.isApprox(eigen_transform_check));
     }


### PR DESCRIPTION
I am not sure what happened, but Visual Studio code was not using the correct settings. Anyone has an idea of what is the most convenient way to run clang-format on a set of files, without using `find` and `xargs` manually?