### PR TITLE
 Add support for forwardKinematics for Fixed and Revolute Joints 

### DIFF
--- a/doc/theory_background.md
+++ b/doc/theory_background.md
@@ -98,7 +98,7 @@ $$
 Note that the $-$ in the axis transformation formula is required to ensure that:
 
 $$
-(H({}^C d^{axis}, {}^C o^{axis}, s) {}^C H_D^{rest})^{-1}  = (H({}^D d^{axis}, {}^D o^{axis}, s) {}^D H_C^{rest})^{-1}
+(H({}^C d^{axis}, {}^C o^{axis}, s) {}^C H_D^{rest})^{-1}  = (H({}^D d^{axis}, {}^D o^{axis}, s) {}^D H_C^{rest})
 $$
 
 

--- a/doc/theory_background.md
+++ b/doc/theory_background.md
@@ -3,6 +3,7 @@
 This document provide an overview of the different semantics between iDynTree and Pinocchio
 data-structures and interfaces, and provide a reference for the implementation in iDynFor classes, that implements iDynTree-inspired interfaces using Pinocchio.
 
+
 ## iDynTree::Model vs pinocchio::Model
 
 ### Link and Joints
@@ -21,6 +22,7 @@ The rest of the model can be connected to the `universe` reference frame with an
 with `iDynTree` the pinocchio models built in `iDynFor` are always connected to "universe" with a `pinocchio::JointFreeFlyer` (i.e. 6-DOF joint).
 
 For these reasons, the count of links and joints in `iDynTree::Model` and  `pinocchio::Model` are different.
+
 For links, in iDynTree only the internal bodies that compose the multibody model are counted, while for `pinocchio` also the `universe` "link" is considered.
 For joints, in iDynTree only the joints that internconnect internal links are considered, while in `pinocchio` two additional joints are considerd:
 * the joint that connects the floating base to `universe`,
@@ -54,6 +56,92 @@ corresponding to ${}^A R_B$, see https://github.com/stack-of-tasks/pinocchio/iss
 
 To convert from the `iDynTree` representation to the `pinocchio` one, one needs to convert the ${}^A H_B$ to the first 7 elements of $q$, and then convert $s$ to the last $dof=nq-7$ elements of $q$, accounting for the fact that the ordering used in iDynTree and in pinocchio is different.
 
+### Joints
+
+#### iDynTree
+
+In iDynTree, the joint information can be accessed via the `iDynTree::IJoint` C++ interface.
+It is an interface that is designed to be `undirect`, i.e. it can explicitly specify at runtime
+which link is the one considred `parent` and which one is considered `child`.
+
+Assuming that the joint `J` connects to links `C` and `D`, and given that $s \in \mathbb{R}^{dof}$ is the vector
+containing the position of internal joints of the, the `iDynTree::IJoint::getTransform(s, C_index, D_index)` computes the transform ${}^C H_D$. How this transform is computed depends on the type of joint used.
+
+##### `FixedJoint`
+
+A fixed joint represent a constraint of all the 6 DOF between two links. So, it is parametrized directly by the transform ${}^C H_D$, and it returns ${}^C H_D$ if `getTransform(s, C_index, D_index)` is called or ${}^C H_D^{-1} = {}}^D H_C$ if `getTransform(s, D_index, C_index)` is called.
+
+##### `RevoluteJoint`
+
+A revolute joint represent a constraint that constraints 5 DOF between two links, leaving the two links free to move around a given axis. So, the relative position between the two links is represented by the so-called joint position $s \in \mathbb{R}^{1}.
+
+So, to represent a `RevoluteJoint` iDynTree uses the following parameters:
+* The rest transform ${}^C H_D^{rest}$, that can be accessed via `iDynTree::getRestTransform(C_index, D_index)`, that is the relative position between the two links when $s = 0$ .
+* The axis along which the rotation is allowed, that is itself represented by two vectors:
+  * The axis direction $d^{axis} \in \mathbb{R}^3$, that being a pure direction is subject to the constraint $|d| = 1$,
+  * The axis origin $^{axis} \in \mathbb{R}^3$, that is a point in the 3D space.
+
+The transform between the frames $C$ and $D$, given the joint position $s$ is computed as in the following:
+$$
+{}^C H_D(s) = H({}^C d^{axis}, {}^C o^{axis}, s) {}^C H_D^{rest}
+$$
+
+The axis can be represented in both $C$ and $D$ frames, and you can go from one to another representation as in the following equations:
+$$
+{}^C d^{axis} = -{}^C R_D {}^D d^{axis}
+$$
+
+$$
+{}^C o^{axis} = {}^C R_D {}^D o^{axis} + {}^C o_D
+$$
+
+Note that the $-$ in the axis transformation formula is required to ensure that:
+$$
+(H({}^C d^{axis}, {}^C o^{axis}, s) {}^C H_D^{rest})^{-1} = (H({}^D d^{axis}, {}^D o^{axis}, s) {}^D H_C^{rest})^{-1}
+$$
 
 
+#### Pinocchio
 
+In pinocchio, a joint connecting a link $C$ and a link $D$ has its own frame, that we will call $J$.
+
+##### FixedJoint
+
+In Pinocchio, to represent a fixed joint there are two transforms:
+* The transform ${}^C H_J$
+* The transform ${}^J H_C$
+
+For the specific case of the FixedJoint, there is no constraint on the location of the frame $J$.
+
+
+##### RevoluteJoint
+
+In Pinocchio, to represent a revolute joint there are two transforms and an axis
+* The transform ${}^C H_J$
+* The transform ${}^J H_D$
+* The axis ${}^J d^{axis}$
+
+And the total rotation is computed as:
+$$
+{}^C H_D (s) = {}^C H_J H({}^J d^{axis}, 0, s) {}^J H_D
+$$
+
+The major difference w.r.t. to iDynTree is that the axis has not notion of "origin", so for placing the frame $J$
+we need to place it in the origin of the axis.
+
+#### Convert from iDynTree to pinocchio
+
+##### FixedJoint
+
+We can simply place $J = D$, and so:
+
+${}^C H_J = {}^C H_J^{rest}$
+${}^J H_D = 1_4$
+
+##### RevoluteJoint
+
+We can simply set the origin of $J$ to match the origin of the axis and the orientation of $J$ to match the orientation of $D$, i.e. $J = (o^{axis},[D])$. Then we set ${}^J H_D$ such that the overall result match.
+
+${}^C H_J = {}^C H_{o^{axis} [D]} = {}^C H_D^{rest} {}^D H_{o^{axis} [D]} = {}^C H_D^{rest} \begin{bmatrix} I_3 & {}^D o^{axis} \\ 0_{3 \times 1}  & 1 \end{bmatrix}$
+${}^J H_D = {}^{o^{axis} [D]} H_D = {}^{o^{axis}[D]} H_D = \begin{bmatrix} I_3 & -{}^D o^{axis} \\ 0_{3 \times 1}  & 1 \end{bmatrix}   $
+${}^J d^{axis} = {}^C d^{axis}$

--- a/doc/theory_background.md
+++ b/doc/theory_background.md
@@ -96,8 +96,9 @@ $$
 $$
 
 Note that the $-$ in the axis transformation formula is required to ensure that:
+
 $$
-(H({}^C d^{axis}, {}^C o^{axis}, s) {}^C H_D^{rest})^{-1} = (H({}^D d^{axis}, {}^D o^{axis}, s) {}^D H_C^{rest})^{-1}
+(H({}^C d^{axis}, {}^C o^{axis}, s) {}^C H_D^{rest})^{-1}  = (H({}^D d^{axis}, {}^D o^{axis}, s) {}^D H_C^{rest})^{-1}
 $$
 
 
@@ -122,6 +123,7 @@ In Pinocchio, to represent a revolute joint there are two transforms and an axis
 * The axis ${}^J d^{axis}$
 
 And the total rotation is computed as:
+
 $$
 {}^C H_D (s) = {}^C H_J H({}^J d^{axis}, 0, s) {}^J H_D
 $$

--- a/doc/theory_background.md
+++ b/doc/theory_background.md
@@ -69,7 +69,7 @@ containing the position of internal joints of the, the `iDynTree::IJoint::getTra
 
 ##### `FixedJoint`
 
-A fixed joint represent a constraint of all the 6 DOF between two links. So, it is parametrized directly by the transform ${}^C H_D$, and it returns ${}^C H_D$ if `getTransform(s, C_index, D_index)` is called or ${}^C H_D^{-1} = {}}^D H_C$ if `getTransform(s, D_index, C_index)` is called.
+A fixed joint represent a constraint of all the 6 DOF between two links. So, it is parametrized directly by the transform ${}^C H_D$, and it returns ${}^C H_D$ if `getTransform(s, C_index, D_index)` is called or ${}^C H_D^{-1} = {}^D H_C$ if `getTransform(s, D_index, C_index)` is called.
 
 ##### `RevoluteJoint`
 

--- a/src/iDynFor/KinDynComputations.h
+++ b/src/iDynFor/KinDynComputations.h
@@ -7,6 +7,7 @@
 #define IDYNfOR_KINDYNCOMPUTATIONS_H
 
 #include <memory>
+#include <vector>
 
 #include <iDynTree/Model/Model.h>
 
@@ -71,6 +72,12 @@ private:
 
     // Base and internal joint position (q)
     VectorXs m_pin_model_position;
+
+    // Conversion-related quantities
+    std::vector<size_t> m_idyntreeDOFOffset2PinocchioJointIndex;
+
+    // Enable printed error messages
+    bool m_verbose = true;
 
     // Cache-related flags methods
     bool m_isFwdKinematicsUpdated = false;

--- a/src/iDynFor/KinDynComputations.tpp
+++ b/src/iDynFor/KinDynComputations.tpp
@@ -55,9 +55,13 @@ void KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::
     Quaternions quaternion(m_world_H_base.rotation());
     m_pin_model_position.block(3, 0, 4, 1) = Eigen::Map<Vector4s>(quaternion.coeffs().data());
 
-    // The rest of the elements are the position of the internal joints, accounting for the
-    // difference in position coordinate serialization between iDynTree and Pinocchio
-    // TODO(traversaro) : handle this
+    // Set internal joint positions
+    for (size_t dof = 0; dof < m_idyntreeModel.getNrOfPosCoords(); dof++)
+    {
+        assert(m_idyntreeDOFOffset2PinocchioJointIndex[dof] >= 7);
+        assert(m_idyntreeDOFOffset2PinocchioJointIndex[dof] < m_pin_model_position.size());
+        m_pin_model_position[m_idyntreeDOFOffset2PinocchioJointIndex[dof]] = m_joint_pos[dof];
+    }
 
     return;
 }
@@ -71,9 +75,15 @@ inline bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::loadRobo
     bool verbose = true;
 
     // TODO: understand if we should catch exception and return bool?
-    iDynFor::buildPinocchioModelfromiDynTree<Scalar, Options, JointCollectionTpl>(m_idyntreeModel,
-                                                                                  m_pinModel,
-                                                                                  verbose);
+    m_modelLoaded = iDynFor::
+        buildPinocchioModelfromiDynTree<Scalar, Options, JointCollectionTpl>(m_idyntreeModel,
+                                                                             m_pinModel,
+                                                                             verbose);
+
+    if (!m_modelLoaded)
+    {
+        return false;
+    }
 
     m_pinData = pinocchio::DataTpl<Scalar, Options, JointCollectionTpl>(m_pinModel);
 
@@ -81,7 +91,34 @@ inline bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::loadRobo
     m_pin_model_position.resize(m_pinModel.nq);
     m_pin_model_position.setZero();
 
-    return (m_modelLoaded = true);
+    // Build the map to convert iDynTree's DOFOffsets to pinocchio::JointIndex
+    m_idyntreeDOFOffset2PinocchioJointIndex.resize(m_idyntreeModel.getNrOfDOFs());
+
+    // The rest of the elements are the position of the internal joints, accounting for the
+    // difference in position coordinate serialization between iDynTree and Pinocchio
+    for (iDynTree::JointIndex jndIndex = 0; jndIndex < m_idyntreeModel.getNrOfJoints(); jndIndex++)
+    {
+        iDynTree::IJointConstPtr visitedJoint = m_idyntreeModel.getJoint(jndIndex);
+        // Note: we are relyng on the assumption (valid as of iDynTree 8.1.0) that all
+        // joints in iDynTree have either 0-dof and 1-dof
+        if (visitedJoint->getNrOfDOFs() != 0)
+        {
+            std::string jntName = m_idyntreeModel.getJointName(visitedJoint->getIndex());
+            if (!m_pinModel.existJointName(jntName))
+            {
+                return false;
+            }
+            // I have no idea why this offset works
+            // TODO: understand
+            size_t posCoordOffsetPinocchio
+                = m_pinModel.joints[m_pinModel.getJointId(jntName)].idx_q();
+            m_idyntreeDOFOffset2PinocchioJointIndex[visitedJoint->getPosCoordsOffset()]
+                = posCoordOffsetPinocchio;
+        }
+    }
+
+    m_modelLoaded = true;
+    return true;
 }
 
 template <typename Scalar, int Options, template <typename, int> class JointCollectionTpl>
@@ -112,6 +149,30 @@ bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::setRobotState(
     const Vector3s& world_gravity)
 {
     this->invalidateCache();
+
+    if (joint_pos.size() != m_idyntreeModel.getNrOfPosCoords())
+    {
+        if (m_verbose)
+        {
+            std::cerr << "iDynFor::KinDynComputationsTpl wrong size of joint_pos argument "
+                         "(required: "
+                      << m_idyntreeModel.getNrOfPosCoords() << ", got: " << joint_pos.size() << ")"
+                      << std::endl;
+        }
+        return false;
+    }
+
+    if (joint_vel.size() != m_idyntreeModel.getNrOfDOFs())
+    {
+        if (m_verbose)
+        {
+            std::cerr << "iDynFor::KinDynComputationsTpl wrong size of joint_vel argument "
+                         "(required: "
+                      << m_idyntreeModel.getNrOfDOFs() << ", got: " << joint_vel.size() << ")"
+                      << std::endl;
+        }
+        return false;
+    }
 
     // Save pos
     m_world_H_base = world_H_base;
@@ -148,11 +209,6 @@ template <typename Scalar, int Options, template <typename, int> class JointColl
 bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::getWorldTransform(
     const iDynTree::FrameIndex frameIndex, SE3s& world_H_frame)
 {
-    // TODO: implement frame different from the base one
-    iDynTree::reportErrorIf(frameIndex != 0,
-                            "iDynFor::KinDynComputationsTpl::getWorldTransform",
-                            "requested frame not supported");
-
     this->computeFwdKinematics();
 
     // Convert iDynTree::FrameIndex to pinocchio::FrameIndex

--- a/src/iDynFor/KinDynComputations.tpp
+++ b/src/iDynFor/KinDynComputations.tpp
@@ -111,7 +111,7 @@ inline bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::loadRobo
             // I have no idea why this offset works
             // TODO: understand
             size_t posCoordOffsetPinocchio
-                = m_pinModel.joints[m_pinModel.getJointId(jntName)].idx_q();
+                = m_pinModel.idx_qs[m_pinModel.getJointId(jntName)];
             m_idyntreeDOFOffset2PinocchioJointIndex[visitedJoint->getPosCoordsOffset()]
                 = posCoordOffsetPinocchio;
         }

--- a/src/iDynFor/KinDynComputations.tpp
+++ b/src/iDynFor/KinDynComputations.tpp
@@ -108,8 +108,6 @@ inline bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::loadRobo
             {
                 return false;
             }
-            // I have no idea why this offset works
-            // TODO: understand
             size_t posCoordOffsetPinocchio
                 = m_pinModel.idx_qs[m_pinModel.getJointId(jntName)];
             m_idyntreeDOFOffset2PinocchioJointIndex[visitedJoint->getPosCoordsOffset()]

--- a/src/iDynFor/iDynTreeFullyCompatibleKinDynComputations.cpp
+++ b/src/iDynFor/iDynTreeFullyCompatibleKinDynComputations.cpp
@@ -16,6 +16,9 @@ namespace iDynTreeFullyCompatible
 struct KinDynComputations::Impl
 {
     iDynFor::KinDynComputationsTpl<double, 0, pinocchio::JointCollectionDefaultTpl> kindyn;
+    // Dummy
+    Eigen::VectorXd bufferJointPos;
+    Eigen::VectorXd bufferJointVel;
 };
 
 KinDynComputations::KinDynComputations()
@@ -52,17 +55,16 @@ bool KinDynComputations::setRobotState(const iDynTree::Transform& world_H_base,
                                        const iDynTree::Vector3& world_gravity)
 {
     // TODO add handling of other arguments
-    Eigen::VectorXd dummy_vec;
     Eigen::Matrix<double, 6, 1> dummy_twist;
     Eigen::Matrix<double, 3, 1> dummy_vec3;
+    m_pimpl->bufferJointPos = iDynTree::toEigen(s);
+    m_pimpl->bufferJointVel = iDynTree::toEigen(s_dot);
 
     return m_pimpl->kindyn.setRobotState(toPinocchio(world_H_base),
-                                         dummy_vec,
+                                         m_pimpl->bufferJointPos,
                                          dummy_twist,
-                                         dummy_vec,
+                                         m_pimpl->bufferJointVel,
                                          dummy_vec3);
-
-    return false;
 }
 
 int KinDynComputations::getFrameIndex(const std::string& frameName) const

--- a/src/iDynFor/iDynTreePinocchioConversions.h
+++ b/src/iDynFor/iDynTreePinocchioConversions.h
@@ -3,15 +3,25 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+// std
+#include <deque>
+
 // pinocchio
 #include <pinocchio/algorithm/frames.hpp>
 #include <pinocchio/fwd.hpp>
 #include <pinocchio/multibody/fwd.hpp>
+#include <pinocchio/multibody/joint/joint-collection.hpp>
 #include <pinocchio/spatial/inertia.hpp>
 
 // iDynTree
+#include <iDynTree/Core/Axis.h>
+#include <iDynTree/Core/EigenHelpers.h>
 #include <iDynTree/Core/SpatialInertia.h>
+#include <iDynTree/Model/FixedJoint.h>
 #include <iDynTree/Model/Model.h>
+#include <iDynTree/Model/PrismaticJoint.h>
+#include <iDynTree/Model/RevoluteJoint.h>
+#include <iDynTree/Model/Traversal.h>
 
 namespace iDynFor
 {
@@ -29,8 +39,6 @@ public:
         REVOLUTE,
         CONTINUOUS,
         PRISMATIC,
-        FLOATING,
-        PLANAR
     };
     typedef _Scalar Scalar;
     typedef pinocchio::SE3Tpl<Scalar, Options> SE3;
@@ -40,12 +48,12 @@ public:
     typedef Eigen::Ref<Vector> VectorRef;
     typedef Eigen::Ref<const Vector> VectorConstRef;
     virtual void setName(const std::string& name) = 0;
-    virtual void addRootJoint(const Inertia& Y, const std::string& body_name) = 0;
+    virtual void addRootJoint(const Inertia& Y, const std::string& bodyName) = 0;
     virtual void addFixedJointAndBody(const pinocchio::FrameIndex& parentFrameId,
                                       const pinocchio::SE3& joint_placement,
                                       const std::string& joint_name,
                                       const pinocchio::Inertia& Y,
-                                      const std::string& body_name)
+                                      const std::string& bodyName)
         = 0;
     iDynTreeModelVisitorBaseTpl()
         : log(NULL)
@@ -71,6 +79,8 @@ public:
     typedef typename Base::SE3 SE3;
     typedef typename Base::Inertia Inertia;
     typedef pinocchio::ModelTpl<Scalar, Options, JointCollectionTpl> Model;
+    typedef pinocchio::FrameTpl<Scalar, Options> Frame;
+    typedef typename Model::JointCollection JointCollection;
     Model& model;
     iDynTreeModelVisitor(Model& model)
         : model(model)
@@ -84,19 +94,19 @@ public:
     void appendBodyToJoint(const pinocchio::FrameIndex fid,
                            const Inertia& Y,
                            const SE3& placement,
-                           const std::string& body_name)
+                           const std::string& bodyName)
 
     {
         const pinocchio::Frame& frame = model.frames[fid];
         const SE3& p = frame.placement * placement;
         model.appendBodyToJoint(frame.parent, Y, p);
-        model.addBodyFrame(body_name, frame.parent, p, static_cast<int>(fid));
+        model.addBodyFrame(bodyName, frame.parent, p, static_cast<int>(fid));
 
         // Reference to model.frames[fid] have changed because the vector
         // may have been reallocated.
     }
 
-    virtual void addRootJoint(const Inertia& Y, const std::string& body_name)
+    virtual void addRootJoint(const Inertia& Y, const std::string& bodyName)
     {
         // Inspired by
         // https://github.com/stack-of-tasks/pinocchio/blob/v2.6.17/src/parsers/urdf/model.hxx#L343
@@ -112,13 +122,14 @@ public:
                                                    "idynfor_root_joint");
 
         pinocchio::FrameIndex jointFrameId = model.addJointFrame(idx, 0);
-        appendBodyToJoint(jointFrameId, Y, SE3::Identity(), body_name);
+        appendBodyToJoint(jointFrameId, Y, SE3::Identity(), bodyName);
     }
+
     virtual void addFixedJointAndBody(const pinocchio::FrameIndex& parent_frame_id,
                                       const pinocchio::SE3& joint_placement,
                                       const std::string& joint_name,
                                       const pinocchio::Inertia& Y,
-                                      const std::string& body_name)
+                                      const std::string& bodyName)
     {
         const pinocchio::Frame& parent_frame = model.frames[parent_frame_id];
         const pinocchio::JointIndex parent_frame_parent = parent_frame.parent;
@@ -131,7 +142,205 @@ public:
                                                                     pinocchio::FIXED_JOINT,
                                                                     Y));
 
-        model.addBodyFrame(body_name, parent_frame_parent, placement, (int)fid);
+        model.addBodyFrame(bodyName, parent_frame_parent, placement, (int)fid);
+    }
+
+    ///
+    /// \brief The four possible cartesian types of an 3D axis.
+    ///
+    enum CartesianAxis
+    {
+        AXIS_X = 0,
+        AXIS_Y = 1,
+        AXIS_Z = 2,
+        AXIS_UNALIGNED
+    };
+
+    ///
+    /// \brief Extract the cartesian property of a particular 3D axis.
+    ///
+    /// \param[in] axis The input iDynTree axis.
+    ///
+    /// \return The property of the particular axis CartesianAxis.
+    ///
+    static inline CartesianAxis extractCartesianAxis(const Vector3& axis)
+    {
+        if (axis == Vector3(1., 0., 0.))
+            return AXIS_X;
+        else if (axis == Vector3(0., 1., 0.))
+            return AXIS_Y;
+        else if (axis == Vector3(0., 0., 1.))
+            return AXIS_Z;
+        else
+            return AXIS_UNALIGNED;
+    }
+
+    template <typename TypeX, typename TypeY, typename TypeZ, typename TypeUnaligned>
+    pinocchio::JointIndex addJoint(const Vector3& axis,
+                                   const Frame& frame,
+                                   const SE3& placement,
+                                   const std::string& joint_name,
+                                   const VectorConstRef& max_effort,
+                                   const VectorConstRef& max_velocity,
+                                   const VectorConstRef& min_config,
+                                   const VectorConstRef& max_config,
+                                   const VectorConstRef& friction,
+                                   const VectorConstRef& damping)
+    {
+        CartesianAxis axisType = extractCartesianAxis(axis);
+        switch (axisType)
+        {
+        case AXIS_X:
+            return model.addJoint(frame.parent,
+                                  TypeX(),
+                                  frame.placement * placement,
+                                  joint_name,
+                                  max_effort,
+                                  max_velocity,
+                                  min_config,
+                                  max_config,
+                                  friction,
+                                  damping);
+            break;
+
+        case AXIS_Y:
+            return model.addJoint(frame.parent,
+                                  TypeY(),
+                                  frame.placement * placement,
+                                  joint_name,
+                                  max_effort,
+                                  max_velocity,
+                                  min_config,
+                                  max_config,
+                                  friction,
+                                  damping);
+            break;
+
+        case AXIS_Z:
+            return model.addJoint(frame.parent,
+                                  TypeZ(),
+                                  frame.placement * placement,
+                                  joint_name,
+                                  max_effort,
+                                  max_velocity,
+                                  min_config,
+                                  max_config,
+                                  friction,
+                                  damping);
+            break;
+
+        case AXIS_UNALIGNED:
+            return model.addJoint(frame.parent,
+                                  TypeUnaligned(axis.normalized()),
+                                  frame.placement * placement,
+                                  joint_name,
+                                  max_effort,
+                                  max_velocity,
+                                  min_config,
+                                  max_config,
+                                  friction,
+                                  damping);
+            break;
+        }
+
+        // Should not be reached
+        assert(false);
+        return static_cast<pinocchio::JointIndex>(-1);
+    }
+
+    void addJointAndBody(JointType type,
+                         const Vector3& axis,
+                         const pinocchio::FrameIndex& parentFrameId,
+                         const SE3& parent_H_joint,
+                         const SE3& joint_H_child,
+                         const std::string& jointName,
+                         const Inertia& Y,
+                         const std::string& bodyName,
+                         const VectorConstRef& maxEffort,
+                         const VectorConstRef& maxVelocity,
+                         const VectorConstRef& minConfig,
+                         const VectorConstRef& maxConfig,
+                         const VectorConstRef& friction,
+                         const VectorConstRef& damping)
+    {
+        pinocchio::JointIndex jointId;
+        const Frame& frame = model.frames[parentFrameId];
+
+        switch (type)
+        {
+        case Base::REVOLUTE:
+            jointId
+                = addJoint<typename JointCollection::JointModelRX,
+                           typename JointCollection::JointModelRY,
+                           typename JointCollection::JointModelRZ,
+                           typename JointCollection::JointModelRevoluteUnaligned>(axis,
+                                                                                  frame,
+                                                                                  parent_H_joint,
+                                                                                  jointName,
+                                                                                  maxEffort,
+                                                                                  maxVelocity,
+                                                                                  minConfig,
+                                                                                  maxConfig,
+                                                                                  friction,
+                                                                                  damping);
+            break;
+        case Base::CONTINUOUS:
+            jointId = addJoint<
+                typename JointCollection::JointModelRUBX,
+                typename JointCollection::JointModelRUBY,
+                typename JointCollection::JointModelRUBZ,
+                typename JointCollection::JointModelRevoluteUnboundedUnaligned>(axis,
+                                                                                frame,
+                                                                                parent_H_joint,
+                                                                                jointName,
+                                                                                maxEffort,
+                                                                                maxVelocity,
+                                                                                minConfig,
+                                                                                maxConfig,
+                                                                                friction,
+                                                                                damping);
+            break;
+        case Base::PRISMATIC:
+            jointId
+                = addJoint<typename JointCollection::JointModelPX,
+                           typename JointCollection::JointModelPY,
+                           typename JointCollection::JointModelPZ,
+                           typename JointCollection::JointModelPrismaticUnaligned>(axis,
+                                                                                   frame,
+                                                                                   parent_H_joint,
+                                                                                   jointName,
+                                                                                   maxEffort,
+                                                                                   maxVelocity,
+                                                                                   minConfig,
+                                                                                   maxConfig,
+                                                                                   friction,
+                                                                                   damping);
+            break;
+        };
+
+        pinocchio::FrameIndex jointFrameId = model.addJointFrame(jointId, (int)parentFrameId);
+        appendBodyToJoint(jointFrameId, Y, joint_H_child, bodyName);
+    }
+
+    virtual void addAdditionalFrame(const std::string& additionalFrameName,
+                                    const std::string& parentLinkName,
+                                    const pinocchio::SE3& link_H_additionalframe)
+    {
+        pinocchio::FrameIndex parentLinkIndex = model.getBodyId(parentLinkName);
+        pinocchio::JointIndex parentJointIndex = model.frames[parentLinkIndex].parent;
+        pinocchio::SE3 joint_H_link = model.frames[parentLinkIndex].placement;
+        pinocchio::SE3 joint_H_additionalframe = joint_H_link * link_H_additionalframe;
+        // The previousFrame attribute is only used to distinguish the interconnection
+        // of multiple frames that are rigidly interconnected to the same joint,
+        // see
+        // https://github.com/stack-of-tasks/pinocchio/blob/78d62096002ffa3790638e392f0b6e4a5efc3d34/src/algorithm/frames.hxx#L280
+        // In this case we are building a Frame with zero inertia, so there previousFrame does not
+        // have any effect, anyhow for consistency we mark the parentLinkIndex as previousFrame
+        model.addFrame(Frame(additionalFrameName,
+                             parentJointIndex,
+                             parentLinkIndex,
+                             joint_H_additionalframe,
+                             pinocchio::OP_FRAME));
     }
 };
 
@@ -153,29 +362,123 @@ iDynTree::Transform fromPinocchio(const pinocchio::SE3& se3_pinocchio);
  */
 pinocchio::Inertia toPinocchio(const iDynTree::SpatialInertia& inertiaIDynTree);
 
+// We vendor here the construction of the traversal as apparently:
+// * Pinocchio requires that models are built in a strictly Depth First order
+// * Despite what the documentaton says, the `Model::computeFullTreeTraversal`
+// does not built the traversal in DF order
+struct stackEl
+{
+    iDynTree::LinkConstPtr link = nullptr;
+    iDynTree::LinkConstPtr parentLink = nullptr;
+    iDynTree::IJointConstPtr parentJoint = nullptr;
+};
+
+inline void iDynFor_addBaseLinkToStack(const iDynTree::Model& model,
+                                       iDynTree::Traversal& traversal,
+                                       iDynTree::LinkIndex linkToAdd,
+                                       std::deque<stackEl>& linkToVisit)
+{
+    stackEl el;
+    el.link = model.getLink(linkToAdd);
+    linkToVisit.push_back(el);
+}
+
+inline void iDynFor_addLinkToStack(const iDynTree::Model& model,
+                                   iDynTree::Traversal& traversal,
+                                   iDynTree::LinkIndex linkToAdd,
+                                   iDynTree::JointIndex parentJointToAdd,
+                                   iDynTree::LinkIndex parentLinkToAdd,
+                                   std::deque<stackEl>& linkToVisit)
+{
+
+    stackEl el;
+    el.link = model.getLink(linkToAdd);
+    el.parentLink = model.getLink(parentLinkToAdd);
+    el.parentJoint = model.getJoint(parentJointToAdd);
+    linkToVisit.push_back(el);
+}
+
+inline bool iDynFor_computeFullTreeTraversal(const iDynTree::Model& model,
+                                             iDynTree::Traversal& traversal,
+                                             const iDynTree::LinkIndex traversalBase)
+{
+    if (traversalBase < 0 || traversalBase >= (iDynTree::LinkIndex)model.getNrOfLinks())
+    {
+        // reportError("Model","computeFullTreeTraversal","requested traversalBase is out of
+        // bounds");
+        return false;
+    }
+
+    // Resetting the traversal for populating it
+    traversal.reset(model);
+
+    // A link is considered visit when all its child (given the traversalBase)
+    // have been added to the traversal
+    std::deque<stackEl> linkToVisit;
+
+    // We add as first link the stack
+    iDynFor_addBaseLinkToStack(model, traversal, traversalBase, linkToVisit);
+
+    // while there is some link still to visit
+    while (linkToVisit.size() > 0)
+    {
+        assert(linkToVisit.size() <= model.getNrOfLinks());
+
+        // DPS : we use linkToVisit as a stack
+        iDynTree::LinkConstPtr visitedLink = linkToVisit.back().link;
+        iDynTree::LinkConstPtr visitedLinkParent = linkToVisit.back().parentLink;
+        iDynTree::IJointConstPtr visitedLinkParentJoint = linkToVisit.back().parentJoint;
+        iDynTree::LinkIndex visitedLinkIndex = visitedLink->getIndex();
+        linkToVisit.pop_back();
+
+        // Add element extracted from the stack to Traversal
+        if (!visitedLinkParent)
+        {
+            traversal.addTraversalBase(visitedLink);
+        } else
+        {
+            traversal.addTraversalElement(visitedLink, visitedLinkParentJoint, visitedLinkParent);
+        }
+
+        for (unsigned int neigh_i = 0; neigh_i < model.getNrOfNeighbors(visitedLinkIndex);
+             neigh_i++)
+        {
+            // add to the stack all the neighbors, except for parent link
+            // (if the visited link is the base one, add all the neighbors)
+            // the visited link is already in the Traversal, so we can use it
+            // to check for its parent
+            iDynTree::Neighbor neighb = model.getNeighbor(visitedLinkIndex, neigh_i);
+            if (visitedLinkParent == 0 || neighb.neighborLink != visitedLinkParent->getIndex())
+            {
+                iDynFor_addLinkToStack(model,
+                                       traversal,
+                                       neighb.neighborLink,
+                                       neighb.neighborJoint,
+                                       visitedLink->getIndex(),
+                                       linkToVisit);
+            }
+        }
+    }
+
+    return true;
+}
+
 /**
  * \brief Build the pinocchio model from a iDynTree::Model .
  *
  * \param[in] model The iDynTree::Model to load.
  * \param[in] verbose Print parsing info.
  * \param[out] model Reference model where to put the parsed information.
- * \return Return the reference on argument model for convenience.
+ * \return Return true if all went well, false otherwise.
  *
  * The signature of this function is inspired from the pinocchio::buildModel function
  */
 template <typename Scalar, int Options, template <typename, int> class JointCollectionTpl>
-pinocchio::ModelTpl<Scalar, Options, JointCollectionTpl>&
-buildPinocchioModelfromiDynTree(const iDynTree::Model& modelIDynTree,
-                                pinocchio::ModelTpl<Scalar, Options, JointCollectionTpl>& modelPin,
-                                const bool verbose = false)
+bool buildPinocchioModelfromiDynTree(
+    const iDynTree::Model& modelIDynTree,
+    pinocchio::ModelTpl<Scalar, Options, JointCollectionTpl>& modelPin,
+    const bool verbose = false)
 {
-    if (modelIDynTree.getNrOfLinks() > 1)
-    {
-        const std::string exception_message("iDynTree::Model has more than one link, only one link "
-                                            "models are supported for now.");
-        throw std::invalid_argument(exception_message);
-    }
-
     // Build visitior
     iDynFor::details::iDynTreeModelVisitor<Scalar, Options, JointCollectionTpl> visitor(modelPin);
 
@@ -183,15 +486,236 @@ buildPinocchioModelfromiDynTree(const iDynTree::Model& modelIDynTree,
     // See https://github.com/robotology/idyntree/issues/908
     visitor.setName("iDynForModel");
 
-    // Extract root link from iDynTree
-    iDynTree::LinkConstPtr defaultBaseLink
-        = modelIDynTree.getLink(modelIDynTree.getDefaultBaseLink());
-    std::string defaultBaseLinkName = modelIDynTree.getLinkName(modelIDynTree.getDefaultBaseLink());
+    // Generate traversal to follow to convert iDynTree::Model to pinocchio::Model
+    // At the moment, we just hardcode the use of getDefaultBaseLink(), but we could
+    // take that as an option in the future
+    iDynTree::Traversal traversal;
+    bool ok = iDynFor_computeFullTreeTraversal(modelIDynTree,
+                                               traversal,
+                                               modelIDynTree.getDefaultBaseLink());
+    if (!ok)
+    {
+        if (verbose)
+        {
+            std::cerr << "iDynFor::buildPinocchioModelfromiDynTree: error in calling "
+                         "computeFullTreeTraversal on input model"
+                      << std::endl;
+        }
+        return false;
+    }
 
-    // Add root link
-    visitor.addRootJoint(toPinocchio(defaultBaseLink->getInertia()), defaultBaseLinkName);
+    for (unsigned int traversalEl = 0; traversalEl < traversal.getNrOfVisitedLinks(); traversalEl++)
+    {
+        iDynTree::LinkConstPtr visitedLink = traversal.getLink(traversalEl);
+        std::string visitedLinkName = modelIDynTree.getLinkName(visitedLink->getIndex());
+        iDynTree::LinkConstPtr parentLink = traversal.getParentLink(traversalEl);
+        iDynTree::IJointConstPtr toParentJoint = traversal.getParentJoint(traversalEl);
 
-    return modelPin;
+        if (parentLink == 0)
+        {
+            // If the visited link is the base, the base has no parent.
+            // Add root link
+            std::string baseLinkName = modelIDynTree.getLinkName(visitedLink->getIndex());
+            visitor.addRootJoint(toPinocchio(visitedLink->getInertia()), baseLinkName);
+        } else
+        {
+            // For non-base links, add the link and the joint connecting it to its parent
+
+            // Part of this code is inspired from
+            // https://github.com/stack-of-tasks/pinocchio/blob/v2.6.17/src/parsers/urdf/model.cpp#L88
+            std::string parentLinkName = modelIDynTree.getLinkName(parentLink->getIndex());
+            std::string jointName = modelIDynTree.getJointName(toParentJoint->getIndex());
+
+            pinocchio::FrameIndex parentFrameId = visitor.model.getBodyId(parentLinkName);
+
+            const pinocchio::Inertia Y = toPinocchio(visitedLink->getInertia());
+
+            Eigen::Matrix<Scalar, Eigen::Dynamic, 1, Options> maxEffort(1), maxVelocity(1),
+                minConfig(1), maxConfig(1);
+            Eigen::Matrix<Scalar, Eigen::Dynamic, 1, Options> friction(1), damping(1);
+
+            const Scalar infty = std::numeric_limits<Scalar>::infinity();
+
+            // Extract joint type
+            // For now, only fixed is supported
+            enum
+            {
+                Revolute,
+                Prismatic,
+                Fixed,
+                NotSupported
+            } parsedJointType;
+
+            parsedJointType = NotSupported;
+
+            if (dynamic_cast<const iDynTree::FixedJoint*>(toParentJoint))
+            {
+                parsedJointType = Fixed;
+            }
+
+            if (dynamic_cast<const iDynTree::RevoluteJoint*>(toParentJoint))
+            {
+                parsedJointType = Revolute;
+            }
+
+            if (dynamic_cast<const iDynTree::PrismaticJoint*>(toParentJoint))
+            {
+                parsedJointType = Prismatic;
+            }
+
+            switch (parsedJointType)
+            {
+                // Code common to 1-dof joints
+            case Revolute:
+            case Prismatic: {
+                typename details::iDynTreeModelVisitorBaseTpl<Scalar, Options>::JointType
+                    pinocchioJointType;
+                iDynTree::Axis axisJoint;
+
+                if (parsedJointType == Revolute)
+                {
+                    pinocchioJointType
+                        = details::iDynTreeModelVisitorBaseTpl<Scalar, Options>::JointType::REVOLUTE;
+                    const iDynTree::RevoluteJoint* revJoint
+                        = dynamic_cast<const iDynTree::RevoluteJoint*>(toParentJoint);
+                    axisJoint = revJoint->getAxis(visitedLink->getIndex());
+                }
+
+                if (parsedJointType == Prismatic)
+                {
+                    pinocchioJointType
+                        = details::iDynTreeModelVisitorBaseTpl<Scalar,
+                                                               Options>::JointType::PRISMATIC;
+                    const iDynTree::PrismaticJoint* prismaticJoint
+                        = dynamic_cast<const iDynTree::PrismaticJoint*>(toParentJoint);
+                    axisJoint = prismaticJoint->getAxis(visitedLink->getIndex());
+                }
+
+                // Extract axis
+                Eigen::Matrix<Scalar, 3, 1, Options> axisDirection_wrt_visitedLink
+                    = iDynTree::toEigen(axisJoint.getDirection());
+                Eigen::Matrix<Scalar, 3, 1, Options> axisOrigin_wrt_visitedLink
+                    = iDynTree::toEigen(axisJoint.getOrigin());
+
+                // See theory_background " Convert from iDynTree to pinocchio" Section for details
+                // on this
+                iDynTree::Transform parentLink_H_childLink_rest
+                    = toParentJoint->getRestTransform(parentLink->getIndex(),
+                                                      visitedLink->getIndex());
+                iDynTree::Transform childLink_H_jointFrame_rest
+                    = iDynTree::Transform(iDynTree::Rotation::Identity(), axisJoint.getOrigin());
+                iDynTree::Transform parentLink_H_jointFrame_rest
+                    = parentLink_H_childLink_rest * childLink_H_jointFrame_rest;
+                iDynTree::Transform jointFrame_H_childLink_rest
+                    = childLink_H_jointFrame_rest.inverse();
+
+                const pinocchio::SE3 parentLink_H_jointFrame
+                    = toPinocchio(parentLink_H_jointFrame_rest);
+                const pinocchio::SE3 jointFrame_H_childLink
+                    = toPinocchio(jointFrame_H_childLink_rest);
+
+                // Handle limits
+                if (toParentJoint->hasPosLimits())
+                {
+                    minConfig[0] = toParentJoint->getMinPosLimit(0);
+                    maxConfig[0] = toParentJoint->getMaxPosLimit(0);
+                } else
+                {
+                    minConfig[0] = -infty;
+                    maxConfig[0] = infty;
+                }
+
+                // This quantities are not exposed by iDynTree, as of 8.0.1
+                friction[0] = 0.0;
+                damping[0] = 0.0;
+                maxEffort[0] = infty;
+                maxVelocity[0] = infty;
+
+                visitor.addJointAndBody(pinocchioJointType,
+                                        axisDirection_wrt_visitedLink,
+                                        parentFrameId,
+                                        parentLink_H_jointFrame,
+                                        jointFrame_H_childLink,
+                                        jointName,
+                                        Y,
+                                        visitedLinkName,
+                                        maxEffort,
+                                        maxVelocity,
+                                        minConfig,
+                                        maxConfig,
+                                        friction,
+                                        damping);
+            }
+            break;
+            case Fixed: {
+                // Transformation from the parent link to the joint origin
+                // In the fixed joint case, the fixed joint frame corresponds to the child link
+                // frame
+                iDynTree::Transform parentLink_H_fixedJointFrame_rest
+                    = toParentJoint->getRestTransform(parentLink->getIndex(),
+                                                      visitedLink->getIndex());
+                const pinocchio::SE3 fixedJointPlacement
+                    = toPinocchio(parentLink_H_fixedJointFrame_rest);
+
+                // In case of fixed joint, if link has inertial tag:
+                //    -add the inertia of the link to his parent in the model
+                // Otherwise do nothing.
+                // In all cases:
+                //    -let all the children become children of parent
+                //    -inform the parser of the offset to apply
+                //    -add fixed body in model for visualization purpouses
+                visitor.addFixedJointAndBody(parentFrameId,
+                                             fixedJointPlacement,
+                                             jointName,
+                                             Y,
+                                             visitedLinkName);
+            }
+            break;
+
+            case NotSupported:
+            default:
+                if (verbose)
+                {
+                    std::cerr << "iDynFor::buildPinocchioModelfromiDynTree: unsupported type for "
+                                 "joint "
+                              << jointName << std::endl;
+                }
+                return false;
+                break;
+            }
+        }
+
+        // Add additional frames of the visited link
+        std::vector<iDynTree::FrameIndex> localFrmIdxs;
+        modelIDynTree.getLinkAdditionalFrames(visitedLink->getIndex(), localFrmIdxs);
+        for (iDynTree::FrameIndex localFrmIdx : localFrmIdxs)
+        {
+            std::string additionalFrameName = modelIDynTree.getFrameName(localFrmIdx);
+            iDynTree::Transform link_H_additionalFrame
+                = modelIDynTree.getFrameTransform(localFrmIdx);
+            visitor.addAdditionalFrame(additionalFrameName,
+                                       visitedLinkName,
+                                       toPinocchio(link_H_additionalFrame));
+        }
+    }
+
+    // Do a sanity check before returning the model
+    // This is expensive, let's do it only in Debug model
+#ifndef NDEBUG
+    auto dataPin = pinocchio::DataTpl<Scalar, Options, JointCollectionTpl>(modelPin);
+    if (!modelPin.check(dataPin))
+    {
+        if (verbose)
+        {
+            std::cerr << "iDynFor::buildPinocchioModelfromiDynTree: error in calling "
+                         "the Data::check on the generated pinocchio model"
+                      << std::endl;
+        }
+        return false;
+    }
+#endif
+
+    return true;
 }
 
 } // namespace iDynFor

--- a/src/iDynFor/iDynTreePinocchioConversions.h
+++ b/src/iDynFor/iDynTreePinocchioConversions.h
@@ -318,7 +318,7 @@ public:
             break;
         };
 
-        pinocchio::FrameIndex jointFrameId = model.addJointFrame(jointId, (int)parentFrameId);
+        pinocchio::FrameIndex jointFrameId = model.addJointFrame(jointId, static_cast<int>(parentFrameId));
         appendBodyToJoint(jointFrameId, Y, joint_H_child, bodyName);
     }
 

--- a/test/LocalModelTestUtils.h
+++ b/test/LocalModelTestUtils.h
@@ -1,0 +1,69 @@
+#ifndef IDYNFOR_LOCAL_MODEL_TEST_UTILS_H
+#define IDYNFOR_LOCAL_MODEL_TEST_UTILS_H
+
+// Functions vendored from
+// https://github.com/robotology/idyntree/blob/4e9d8097753dc146914e55f5656b465d00e6b25f/src/model/include/iDynTree/Model/ModelTestUtils.h#L118
+// As we currently need to customize them until iDynFor support all features of iDynTree::Model
+inline void iDynFor_addRandomLinkToModel(iDynTree::Model& model,
+                                         std::string parentLink,
+                                         std::string newLinkName,
+                                         bool noFixed = false)
+{
+    // Add Link
+    iDynTree::LinkIndex newLinkIndex = model.addLink(newLinkName, iDynTree::getRandomLink());
+
+    // Now add joint
+    iDynTree::LinkIndex parentLinkIndex = model.getLinkIndex(parentLink);
+
+    // Only consider fixed (0) and revolute (1)
+    int nrOfJointTypes = 2;
+
+    int jointType = rand() % nrOfJointTypes;
+
+    if (noFixed)
+        jointType = 1;
+
+    if (jointType == 0)
+    {
+        iDynTree::FixedJoint fixJoint(parentLinkIndex,
+                                      newLinkIndex,
+                                      iDynTree::getRandomTransform());
+        model.addJoint(newLinkName + "joint", &fixJoint);
+    } else if (jointType == 1)
+    {
+        iDynTree::RevoluteJoint revJoint;
+        revJoint.setAttachedLinks(parentLinkIndex, newLinkIndex);
+        revJoint.setRestTransform(iDynTree::getRandomTransform());
+        revJoint.setAxis(iDynTree::getRandomAxis(), newLinkIndex);
+        model.addJoint(newLinkName + "joint", &revJoint);
+    } else
+    {
+        assert(false);
+    }
+}
+
+inline iDynTree::Model
+iDynFor_getRandomModel(unsigned int nrOfJoints, size_t nrOfAdditionalFrames = 10)
+{
+    iDynTree::Model model;
+
+    model.addLink("baseLink", iDynTree::getRandomLink());
+
+    for (unsigned int i = 0; i < nrOfJoints; i++)
+    {
+        std::string parentLink = getRandomLinkOfModel(model);
+        std::string linkName = "link" + iDynTree::int2string(i);
+        iDynFor_addRandomLinkToModel(model, parentLink, linkName);
+    }
+
+    for (unsigned int i = 0; i < nrOfAdditionalFrames; i++)
+    {
+        std::string parentLink = getRandomLinkOfModel(model);
+        std::string frameName = "additionalFrame" + iDynTree::int2string(i);
+        addRandomAdditionalFrameToModel(model, parentLink, frameName);
+    }
+
+    return model;
+}
+
+#endif


### PR DESCRIPTION
Fix https://github.com/ami-iit/idynfor/issues/24 .

The PR is a bit dirty, has more code that I would like for a PR, and as I still need to report the following problem upstream:
* pinocchio: undocumented requirements of calling addJoint in depth-first order ( https://github.com/stack-of-tasks/pinocchio/issues/1897 )
* pinocchio: document how to access the position variables of a given joint (
this is actually quite clearly documented in `pinocchio::ModelTpl` `idx_qs` and `idx_vs` attributes: https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/master/doxygen-html/structpinocchio_1_1ModelTpl.html#a5956b0de4ba79cb09d15c7d82a9acf0a ) 
* iDynTree: bug in `Model::computeFullTreeTraversal`, that claim to populate the traversal with a depth-first search, when actually it does not. ( https://github.com/robotology/idyntree/issues/1055 )
* iDynTree: bug in `iDynTree::getRandomModel` that never generates a model with a TranslationalJoint (https://github.com/robotology/idyntree/issues/1054)
* iDynTree: the semantics of `Joint::setAxis` is confusing ( https://github.com/robotology/idyntree/issues/1056 )

Furthermore, the theory document still needs to be update. However, this is the first non-trivial functionality that works, so I am quite happy anyhow of it.

