### PR TITLE
Add implementation for velocity forward kinematics

### DIFF
--- a/src/iDynFor/iDynTreeFullyCompatibleKinDynComputations.h
+++ b/src/iDynFor/iDynTreeFullyCompatibleKinDynComputations.h
@@ -9,6 +9,8 @@
 #include <memory>
 
 #include <iDynTree/Model/Model.h>
+// This header provides the iDynTree::FrameVelocityRepresentation enum
+#include <iDynTree/Model/FreeFloatingMatrices.h>
 
 namespace iDynFor
 {
@@ -39,6 +41,9 @@ public:
     bool loadRobotModel(const iDynTree::Model& model);
     bool isValid() const;
 
+    bool setFrameVelocityRepresentation(const iDynTree::FrameVelocityRepresentation frameVelRepr);
+    iDynTree::FrameVelocityRepresentation getFrameVelocityRepresentation() const;
+
     const iDynTree::Model& model() const;
     const iDynTree::Model& getRobotModel() const;
 
@@ -51,6 +56,11 @@ public:
     int getFrameIndex(const std::string& frameName) const;
     std::string getFrameName(const iDynTree::FrameIndex frameIndex) const;
     iDynTree::Transform getWorldTransform(const iDynTree::FrameIndex frameIndex);
+
+    iDynTree::Twist getFrameVel(const std::string& frameName);
+    bool getFrameVel(const std::string& frameName, iDynTree::Span<double> twist);
+    iDynTree::Twist getFrameVel(const iDynTree::FrameIndex frameIdx);
+    bool getFrameVel(const iDynTree::FrameIndex frameIdx, iDynTree::Span<double> twist);
 };
 
 } // namespace iDynTreeFullyCompatible

--- a/src/iDynFor/iDynTreePinocchioConversions.h
+++ b/src/iDynFor/iDynTreePinocchioConversions.h
@@ -22,6 +22,8 @@
 #include <iDynTree/Model/PrismaticJoint.h>
 #include <iDynTree/Model/RevoluteJoint.h>
 #include <iDynTree/Model/Traversal.h>
+// This header provides the iDynTree::FrameVelocityRepresentation enum
+#include <iDynTree/Model/FreeFloatingMatrices.h>
 
 namespace iDynFor
 {
@@ -318,7 +320,8 @@ public:
             break;
         };
 
-        pinocchio::FrameIndex jointFrameId = model.addJointFrame(jointId, static_cast<int>(parentFrameId));
+        pinocchio::FrameIndex jointFrameId
+            = model.addJointFrame(jointId, static_cast<int>(parentFrameId));
         appendBodyToJoint(jointFrameId, Y, joint_H_child, bodyName);
     }
 
@@ -361,6 +364,27 @@ iDynTree::Transform fromPinocchio(const pinocchio::SE3& se3_pinocchio);
  * Convert an iDynTree::SpatialInertia to a pinocchio::Inertia
  */
 pinocchio::Inertia toPinocchio(const iDynTree::SpatialInertia& inertiaIDynTree);
+
+/**
+ * Convert an iDynTree::FrameVelocityRepresentation to a pinocchio::ReferenceFrame
+ */
+inline pinocchio::ReferenceFrame
+toPinocchio(const iDynTree::FrameVelocityRepresentation frameVelRepr)
+{
+    switch (frameVelRepr)
+    {
+    case iDynTree::INERTIAL_FIXED_REPRESENTATION:
+        return pinocchio::WORLD;
+    case iDynTree::BODY_FIXED_REPRESENTATION:
+        return pinocchio::LOCAL;
+    case iDynTree::MIXED_REPRESENTATION:
+        return pinocchio::LOCAL_WORLD_ALIGNED;
+    }
+
+    // Avoid warnings
+    assert(false);
+    return pinocchio::LOCAL_WORLD_ALIGNED;
+}
 
 // We vendor here the construction of the traversal as apparently:
 // * Pinocchio requires that models are built in a strictly Depth First order

--- a/test/KinDynComputationsTest.cpp
+++ b/test/KinDynComputationsTest.cpp
@@ -37,6 +37,11 @@ TEST_CASE("KinDynComputations")
         bool okLoad = kinDynFor.loadRobotModel(idynmodel);
         REQUIRE(okLoad);
 
+        // Set random velocity representation
+        iDynTree::FrameVelocityRepresentation velRepr = iDynFor_getRandomVelocityRepresentation();
+        REQUIRE(kinDynTree.setFrameVelocityRepresentation(velRepr));
+        REQUIRE(kinDynFor.setFrameVelocityRepresentation(velRepr));
+
         // After calling loadRobotModel, isValid should return true
         REQUIRE(kinDynTree.isValid());
         REQUIRE(kinDynFor.isValid());
@@ -72,6 +77,7 @@ TEST_CASE("KinDynComputations")
                 REQUIRE(kinDynFor.getFrameIndex(frameName) == randomFrameIndex);
                 REQUIRE(kinDynFor.getFrameIndex(frameName) == kinDynTree.getFrameIndex(frameName));
 
+                // Test getWorldTransform
                 Eigen::Matrix4d worldTransformFor = iDynTree::toEigen(
                     kinDynFor.getWorldTransform(randomFrameIndex).asHomogeneousTransform());
                 Eigen::Matrix4d worldTransformTree = iDynTree::toEigen(
@@ -81,8 +87,14 @@ TEST_CASE("KinDynComputations")
                 // std::cerr << "WorldTransform of " <<
                 // kinDynFor.model().getFrameName(randomFrameIndex) << std::endl; std::cerr <<
                 // worldTransformFor << std::endl; std::cerr << worldTransformTree << std::endl;
-
                 REQUIRE(worldTransformFor.isApprox(worldTransformTree));
+
+                // Test getFrameVel
+                Eigen::Vector<double, 6> frameVelFor
+                    = iDynTree::toEigen(kinDynFor.getFrameVel(randomFrameIndex));
+                Eigen::Vector<double, 6> frameVelTree
+                    = iDynTree::toEigen(kinDynTree.getFrameVel(randomFrameIndex));
+                REQUIRE(frameVelFor.isApprox(frameVelTree));
             }
         }
     }

--- a/test/LocalModelTestUtils.h
+++ b/test/LocalModelTestUtils.h
@@ -1,6 +1,28 @@
 #ifndef IDYNFOR_LOCAL_MODEL_TEST_UTILS_H
 #define IDYNFOR_LOCAL_MODEL_TEST_UTILS_H
 
+#include <iDynTree/Model/Model.h>
+// This header provides the iDynTree::FrameVelocityRepresentation enum
+#include <iDynTree/Model/FreeFloatingMatrices.h>
+
+inline iDynTree::FrameVelocityRepresentation iDynFor_getRandomVelocityRepresentation()
+{
+    size_t representation = rand() % 3;
+    switch (representation)
+    {
+    case 0:
+        return iDynTree::INERTIAL_FIXED_REPRESENTATION;
+    case 1:
+        return iDynTree::BODY_FIXED_REPRESENTATION;
+    case 2:
+        return iDynTree::MIXED_REPRESENTATION;
+    }
+
+    // Just to avoid warnings
+    assert(false);
+    return iDynTree::MIXED_REPRESENTATION;
+}
+
 // Functions vendored from
 // https://github.com/robotology/idyntree/blob/4e9d8097753dc146914e55f5656b465d00e6b25f/src/model/include/iDynTree/Model/ModelTestUtils.h#L118
 // As we currently need to customize them until iDynFor support all features of iDynTree::Model


### PR DESCRIPTION
Fix https://github.com/ami-iit/idynfor/issues/27 .

I still need to update the `doc/theory_background.md` document, but fortunatly the implementation was quite simple due to the following reasons:
* the logic for converting the base velocity used by iDynTree to the one used pinocchio is simply to convert the velocity from the representation used in the iDynTree case (by default mixed) to the one used in Pinocchio, that is always base-fixed/left-trivialized. Fortunatly, both pinocchio and iDynTree share the same linear/angular serialization for 6D quantities, as opposed to Featherstone that instead uses the angular/linear serialization.
* the logic for mapping internal joint velocities between iDynTree and pinocchio is exactly the same for mapping internal joint positions.
* once the required velocity is computed, there is no need to convert anything from pinocchio: the [`pinocchio::getFrameVelocity`](https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/master/doxygen-html/namespacepinocchio.html#aeff1f1c50eaa6a706ac2271a4d70a2cd) function can handle all the velocity representations supported by iDynTree, so we just need to specify the representation we want by converting from `iDynTree::FrameVelocityRepresentation` to `pinocchio::ReferenceFrame`

Some of the theory used in this PR was already covered in https://github.com/robotology/idyntree/issues/674#issuecomment-1079669767 .