### PR TITLE
Implement getRobotState and reduce memory allocation

### DIFF
--- a/src/iDynFor/KinDynComputations.h
+++ b/src/iDynFor/KinDynComputations.h
@@ -189,10 +189,10 @@ public:
      * @return true if all went well, false otherwise.
      */
     bool setRobotState(const SE3s& world_H_base,
-                       const VectorXs& s,
-                       const Vector6s& base_velocity,
-                       const VectorXs& s_dot,
-                       const Vector3s& world_gravity);
+                       const Eigen::Ref<const VectorXs>& joint_pos,
+                       const Eigen::Ref<const Vector6s>& base_velocity,
+                       const Eigen::Ref<const VectorXs>& joint_vel,
+                       const Eigen::Ref<const Vector3s>& world_gravity);
 
     /**
      * Get the index corresponding to a given frame name.

--- a/src/iDynFor/KinDynComputations.h
+++ b/src/iDynFor/KinDynComputations.h
@@ -195,6 +195,39 @@ public:
                        const Eigen::Ref<const Vector3s>& world_gravity);
 
     /**
+     * Get the state for the robot (floating base)
+     *
+     * @param world_H_base  the homogeneous transformation that transforms position vectors
+     * expressed in the base reference frame in position frames expressed in the world reference
+     * frame (i.e. pos_world = world_H_base*pos_base .
+     * @param s a vector of getNrOfDegreesOfFreedom() joint positions (in rad)
+     * @param base_velocity The twist (linear/angular velocity) of the base, expressed with the
+     * convention specified by the used FrameVelocityConvention.
+     * @param s_dot a vector of getNrOfDegreesOfFreedom() joint velocities (in rad/sec)
+     * @param world_gravity a 3d vector of the gravity acceleration vector, expressed in the
+     * world/inertial frame.
+     * @return true if all went well, false otherwise.
+     */
+    bool getRobotState(SE3s& world_H_base,
+                       Eigen::Ref<VectorXs> s,
+                       Eigen::Ref<Vector6s> base_velocity,
+                       Eigen::Ref<VectorXs> s_dot,
+                       Eigen::Ref<Vector3s> world_gravity) const;
+
+    /**
+     * Get the state for the robot (floating base)
+     *
+     * @param s a vector of getNrOfDegreesOfFreedom() joint positions (in rad)
+     * @param s_dot a vector of getNrOfDegreesOfFreedom() joint velocities (in rad/sec)
+     * @param world_gravity a 3d vector of the gravity acceleration vector, expressed in the
+     * world/inertial frame.
+     * @return true if all went well, false otherwise.
+     */
+    bool getRobotState(Eigen::Ref<VectorXs> s,
+                       Eigen::Ref<VectorXs> s_dot,
+                       Eigen::Ref<Vector3s> world_gravity) const;
+
+    /**
      * Get the index corresponding to a given frame name.
      * @return a integer greater than or equal to zero if the frame exist,
      *         a negative integer otherwise.

--- a/src/iDynFor/KinDynComputations.tpp
+++ b/src/iDynFor/KinDynComputations.tpp
@@ -328,6 +328,50 @@ bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::setRobotState(
 }
 
 template <typename Scalar, int Options, template <typename, int> class JointCollectionTpl>
+bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::getRobotState(
+    SE3s& world_H_base,
+    Eigen::Ref<VectorXs> joint_pos,
+    Eigen::Ref<Vector6s> base_velocity,
+    Eigen::Ref<VectorXs> joint_vel,
+    Eigen::Ref<Vector3s> world_gravity) const
+{
+    world_H_base = m_world_H_base;
+    base_velocity = m_base_velocity;
+    return this->getRobotState(joint_pos, joint_vel, world_gravity);
+}
+
+template <typename Scalar, int Options, template <typename, int> class JointCollectionTpl>
+bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::getRobotState(
+    Eigen::Ref<VectorXs> joint_pos,
+    Eigen::Ref<VectorXs> joint_vel,
+    Eigen::Ref<Vector3s> world_gravity) const
+{
+    if (joint_pos.size() != m_idyntreeModel.getNrOfDOFs())
+    {
+        std::cerr << "iDynFor::KinDynComputationsTpl wrong size of joint_pos argument "
+                     "(required: "
+                  << m_idyntreeModel.getNrOfDOFs() << ", got: " << joint_pos.size() << ")"
+                  << std::endl;
+        return false;
+    }
+
+    if (joint_vel.size() != m_idyntreeModel.getNrOfDOFs())
+    {
+        std::cerr << "iDynFor::KinDynComputationsTpl wrong size of joint_vel argument "
+                     "(required: "
+                  << m_idyntreeModel.getNrOfDOFs() << ", got: " << joint_vel.size() << ")"
+                  << std::endl;
+        return false;
+    }
+
+    joint_pos = m_joint_pos;
+    joint_vel = m_joint_vel;
+    world_gravity = m_world_gravity;
+
+    return true;
+}
+
+template <typename Scalar, int Options, template <typename, int> class JointCollectionTpl>
 int KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::getFrameIndex(
     const std::string& frameName) const
 {

--- a/src/iDynFor/KinDynComputations.tpp
+++ b/src/iDynFor/KinDynComputations.tpp
@@ -282,10 +282,10 @@ bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::setFrameVelocit
 template <typename Scalar, int Options, template <typename, int> class JointCollectionTpl>
 bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::setRobotState(
     const SE3s& world_H_base,
-    const VectorXs& joint_pos,
-    const Vector6s& base_velocity,
-    const VectorXs& joint_vel,
-    const Vector3s& world_gravity)
+    const Eigen::Ref<const VectorXs>& joint_pos,
+    const Eigen::Ref<const Vector6s>& base_velocity,
+    const Eigen::Ref<const VectorXs>& joint_vel,
+    const Eigen::Ref<const Vector3s>& world_gravity)
 {
     this->invalidateCache();
 

--- a/src/iDynFor/iDynTreeFullyCompatibleKinDynComputations.h
+++ b/src/iDynFor/iDynTreeFullyCompatibleKinDynComputations.h
@@ -53,6 +53,12 @@ public:
                        const iDynTree::VectorDynSize& s_dot,
                        const iDynTree::Vector3& world_gravity);
 
+    void getRobotState(iDynTree::Transform& world_T_base,
+                       iDynTree::VectorDynSize& s,
+                       iDynTree::Twist& base_velocity,
+                       iDynTree::VectorDynSize& s_dot,
+                       iDynTree::Vector3& world_gravity) const;
+
     int getFrameIndex(const std::string& frameName) const;
     std::string getFrameName(const iDynTree::FrameIndex frameIndex) const;
     iDynTree::Transform getWorldTransform(const iDynTree::FrameIndex frameIndex);

--- a/test/KinDynComputationsTest.cpp
+++ b/test/KinDynComputationsTest.cpp
@@ -90,9 +90,9 @@ TEST_CASE("KinDynComputations")
                 REQUIRE(worldTransformFor.isApprox(worldTransformTree));
 
                 // Test getFrameVel
-                Eigen::Vector<double, 6> frameVelFor
+                Eigen::Matrix<double, 6, 1> frameVelFor
                     = iDynTree::toEigen(kinDynFor.getFrameVel(randomFrameIndex));
-                Eigen::Vector<double, 6> frameVelTree
+                Eigen::Matrix<double, 6, 1> frameVelTree
                     = iDynTree::toEigen(kinDynTree.getFrameVel(randomFrameIndex));
                 REQUIRE(frameVelFor.isApprox(frameVelTree));
 

--- a/test/KinDynComputationsTest.cpp
+++ b/test/KinDynComputationsTest.cpp
@@ -66,6 +66,23 @@ TEST_CASE("KinDynComputations")
                 kinDynTree.setRobotState(world_H_base, joint_pos, base_vel, joint_vel, gravity));
             REQUIRE(kinDynFor.setRobotState(world_H_base, joint_pos, base_vel, joint_vel, gravity));
 
+            iDynTree::Transform world_H_base_copy;
+            iDynTree::Twist base_vel_copy;
+            iDynTree::Vector3 gravity_copy;
+            iDynTree::VectorDynSize joint_pos_copy, joint_vel_copy;
+            kinDynFor.getRobotState(world_H_base_copy,
+                                    joint_pos_copy,
+                                    base_vel_copy,
+                                    joint_vel_copy,
+                                    gravity_copy);
+
+            REQUIRE(iDynTree::toEigen(world_H_base_copy.asHomogeneousTransform())
+                        .isApprox(iDynTree::toEigen(world_H_base.asHomogeneousTransform())));
+            REQUIRE(iDynTree::toEigen(joint_pos_copy).isApprox(iDynTree::toEigen(joint_pos)));
+            REQUIRE(iDynTree::toEigen(base_vel_copy).isApprox(iDynTree::toEigen(base_vel)));
+            REQUIRE(iDynTree::toEigen(joint_vel_copy).isApprox(iDynTree::toEigen(joint_vel)));
+            REQUIRE(iDynTree::toEigen(gravity_copy).isApprox(iDynTree::toEigen(gravity)));
+
             // Test frame-related methods
             int nrOfFramesToTest = 20;
             for (int fr = 0; fr < nrOfFramesToTest; fr++)


### PR DESCRIPTION
This PR implements getRobotState and reduced the memory allocation by using `Eigen::Ref<>` instead of normal reference in the set and get state. 

cc @isorrentino 