### PR TITLE
Add benchmarks using Catch2's benchmark functionality

### DIFF
--- a/.github/workflows/conda-forge-ci.yaml
+++ b/.github/workflows/conda-forge-ci.yaml
@@ -43,7 +43,7 @@ jobs:
       shell: bash -l {0}
       run: |
         mkdir -p build
-        cd build    
+        cd build
         cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DBUILD_TESTING:BOOL=ON ..
 
@@ -58,11 +58,17 @@ jobs:
       shell: bash -l {0}
       run: |
         cd build
-        cmake --build . --config ${{ matrix.build_type }} 
+        cmake --build . --config ${{ matrix.build_type }}
 
     - name: Test
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
         cd build
-        ctest  --repeat until-pass:5 --output-on-failure -C ${{ matrix.build_type }} .
+        ctest  --repeat until-pass:5 --output-on-failure -E "Benchmark" -C ${{ matrix.build_type }} .
+
+    - name: Benchmark
+      shell: bash -l {0}
+      run: |
+        cd build
+        ctest -R "Benchmark" -C ${{ matrix.build_type }} -VV .

--- a/src/iDynFor/KinDynComputations.h
+++ b/src/iDynFor/KinDynComputations.h
@@ -83,6 +83,8 @@ private:
     // Conversion-related quantities
     std::vector<size_t> m_idyntreeDOFOffset2PinocchioJointPosOffset;
     std::vector<size_t> m_idyntreeDOFOffset2PinocchioJointVelOffset;
+    std::vector<pinocchio::FrameIndex> m_idyntreeFrameIndex2PinocchioFrameIndex;
+
     // Permutation matrix, see "Model Position" section of doc/theory_background.md
     Eigen::PermutationMatrix<Eigen::Dynamic> m_pinocchio_P_idyntree;
 

--- a/src/iDynFor/KinDynComputations.tpp
+++ b/src/iDynFor/KinDynComputations.tpp
@@ -177,6 +177,8 @@ inline bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::loadRobo
     m_pin_model_velocity.setZero();
 
     // Build the map to convert iDynTree indeces to Pinocchio indeces
+
+    //// Joint-related indices
     m_idyntreeDOFOffset2PinocchioJointPosOffset.resize(m_idyntreeModel.getNrOfDOFs());
     m_idyntreeDOFOffset2PinocchioJointVelOffset.resize(m_idyntreeModel.getNrOfDOFs());
 
@@ -206,6 +208,16 @@ inline bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::loadRobo
                 = velocityOffsetPinocchio;
         }
     }
+
+    //// Frame indices
+    m_idyntreeFrameIndex2PinocchioFrameIndex.resize(m_idyntreeModel.getNrOfFrames());
+
+    for (iDynTree::FrameIndex frameIndex = 0; frameIndex < m_idyntreeModel.getNrOfFrames(); frameIndex++)
+    {
+        m_idyntreeFrameIndex2PinocchioFrameIndex[frameIndex]
+            = m_pinModel.getFrameId(m_idyntreeModel.getFrameName(frameIndex));
+    }
+
 
     // Create permutation matrix
     m_pinocchio_P_idyntree.resize(m_idyntreeModel.getNrOfDOFs());
@@ -395,9 +407,8 @@ bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::getWorldTransfo
 
     // Convert iDynTree::FrameIndex to pinocchio::FrameIndex
     // TODO(traversaro): also support additional frames, not only frames associated to a link
-    // TODO(traversaro): cache this information, there is no need to do a string search every time
     pinocchio::FrameIndex pinFrameIndex
-        = m_pinModel.getFrameId(m_idyntreeModel.getFrameName(frameIndex));
+        = m_idyntreeFrameIndex2PinocchioFrameIndex[frameIndex];
 
     // After computeFwdKinematics computed the forwardKinematics, in m_pinData it is
     // store the universe_H_<..> transform for each joint frame
@@ -418,9 +429,8 @@ bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::getFrameVel(
     this->computeFwdKinematics();
 
     // Convert iDynTree::FrameIndex to pinocchio::FrameIndex
-    // TODO(traversaro): cache this information, there is no need to do a string search every time
     pinocchio::FrameIndex pinFrameIndex
-        = m_pinModel.getFrameId(m_idyntreeModel.getFrameName(frameIndex));
+        = m_idyntreeFrameIndex2PinocchioFrameIndex[frameIndex];
 
     frameVel = pinocchio::getFrameVelocity(m_pinModel,
                                            m_pinData,
@@ -458,7 +468,7 @@ bool KinDynComputationsTpl<Scalar, Options, JointCollectionTpl>::getFrameFreeFlo
     // Convert iDynTree::FrameIndex to pinocchio::FrameIndex
     // TODO(traversaro): cache this information, there is no need to do a string search every time
     pinocchio::FrameIndex pinFrameIndex
-        = m_pinModel.getFrameId(m_idyntreeModel.getFrameName(frameIndex));
+        = m_idyntreeFrameIndex2PinocchioFrameIndex[frameIndex];
 
     // Compute Jacobian that on left has the right representation (as we pass it via toPinocchio(m_frameVelRepr))
     // but on the left accepts v^{pin} and not v^{idyn} (as defined in doc/theory_background.md)

--- a/src/iDynFor/iDynTreePinocchioConversions.h
+++ b/src/iDynFor/iDynTreePinocchioConversions.h
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
 // SPDX-License-Identifier: BSD-3-Clause
 
+#ifndef IDYNFOR_IDYNTREEPINOCCHIOCONVERSIONS_H
+#define IDYNFOR_IDYNTREEPINOCCHIOCONVERSIONS_H
+
 // std
 #include <deque>
 
@@ -741,3 +744,5 @@ bool buildPinocchioModelfromiDynTree(
 }
 
 } // namespace iDynFor
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,3 +8,8 @@ add_idynfor_test(NAME iDynTreePinocchioConversionsTest
 add_idynfor_test(NAME KinDynComputationsTest
                  SOURCES KinDynComputationsTest.cpp
                  LINKS iDynFor::iDynFor iDynTree::idyntree-high-level)
+
+
+add_idynfor_test(NAME KinDynComputationsBenchmark
+                 SOURCES KinDynComputationsBenchmark.cpp
+                 LINKS iDynFor::iDynFor iDynTree::idyntree-high-level)

--- a/test/KinDynComputationsBenchmark.cpp
+++ b/test/KinDynComputationsBenchmark.cpp
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <iDynFor/iDynTreeFullyCompatibleKinDynComputations.h>
+#include <iDynFor/KinDynComputations.h>
+#include <iDynFor/iDynTreePinocchioConversions.h>
+
+#include <iDynTree/KinDynComputations.h>
+
+
+#include <iDynTree/Core/EigenHelpers.h>
+#include <iDynTree/Core/TestUtils.h>
+#include <iDynTree/Model/ModelTestUtils.h>
+
+#include "LocalModelTestUtils.h"
+
+
+bool setRandomState(iDynFor::iDynTreeFullyCompatible::KinDynComputations& kinDynFor)
+{
+    // Set random state
+    iDynTree::Transform world_H_base = iDynTree::getRandomTransform();
+    iDynTree::Twist base_vel = iDynTree::getRandomTwist();
+    iDynTree::Vector3 gravity;
+    iDynTree::getRandomVector(gravity);
+    iDynTree::VectorDynSize joint_pos, joint_vel;
+    joint_pos.resize(kinDynFor.model().getNrOfPosCoords());
+    joint_vel.resize(kinDynFor.model().getNrOfDOFs());
+    iDynTree::getRandomVector(joint_pos);
+    iDynTree::getRandomVector(joint_vel);
+    return kinDynFor.setRobotState(world_H_base, joint_pos, base_vel, joint_vel, gravity);
+}
+
+bool setRandomState(iDynTree::KinDynComputations& kinDynTree)
+{
+    // Set random state
+    iDynTree::Transform world_H_base = iDynTree::getRandomTransform();
+    iDynTree::Twist base_vel = iDynTree::getRandomTwist();
+    iDynTree::Vector3 gravity;
+    iDynTree::getRandomVector(gravity);
+    iDynTree::VectorDynSize joint_pos, joint_vel;
+    joint_pos.resize(kinDynTree.model().getNrOfPosCoords());
+    joint_vel.resize(kinDynTree.model().getNrOfDOFs());
+    iDynTree::getRandomVector(joint_pos);
+    iDynTree::getRandomVector(joint_vel);
+    return kinDynTree.setRobotState(world_H_base, joint_pos, base_vel, joint_vel, gravity);
+}
+
+bool setRandomState(iDynFor::KinDynComputationsTpl<double, 0, pinocchio::JointCollectionDefaultTpl>& kinDynForEigen)
+{
+    size_t nrOfInternalDOFs = kinDynForEigen.model().getNrOfDOFs();
+    iDynFor::KinDynComputationsTpl<double, 0, pinocchio::JointCollectionDefaultTpl>::SE3s world_H_base
+        = iDynFor::toPinocchio(iDynTree::getRandomTransform());
+    iDynFor::KinDynComputationsTpl<double, 0, pinocchio::JointCollectionDefaultTpl>::Vector6s base_vel =
+        iDynFor::KinDynComputationsTpl<double, 0, pinocchio::JointCollectionDefaultTpl>::Vector6s::Random();
+    iDynFor::KinDynComputationsTpl<double, 0, pinocchio::JointCollectionDefaultTpl>::Vector3s gravity =
+            iDynFor::KinDynComputationsTpl<double, 0, pinocchio::JointCollectionDefaultTpl>::Vector3s::Random();
+    iDynFor::KinDynComputationsTpl<double, 0, pinocchio::JointCollectionDefaultTpl>::VectorXs joint_pos
+        = iDynFor::KinDynComputationsTpl<double, 0, pinocchio::JointCollectionDefaultTpl>::VectorXs::Random(nrOfInternalDOFs, 1);
+    iDynFor::KinDynComputationsTpl<double, 0, pinocchio::JointCollectionDefaultTpl>::VectorXs joint_vel
+        = iDynFor::KinDynComputationsTpl<double, 0, pinocchio::JointCollectionDefaultTpl>::VectorXs::Random(nrOfInternalDOFs, 1);
+    return kinDynForEigen.setRobotState(world_H_base, joint_pos, base_vel, joint_vel, gravity);
+}
+
+
+TEST_CASE("KinDynComputations Benchmarks")
+{
+    // Seed the random generator used by iDynTree
+    srand(0);
+
+    size_t nrOfLinks = 25;
+    size_t nrOfAdditionalFrames = 10;
+    iDynTree::Model idynmodel = iDynFor_getRandomModel(nrOfLinks, nrOfAdditionalFrames);
+
+    // Create both a new and and old KinDynComputations to check consistency
+    iDynFor::iDynTreeFullyCompatible::KinDynComputations kinDynFor;
+    iDynFor::KinDynComputationsTpl<double, 0, pinocchio::JointCollectionDefaultTpl> kinDynForEigen;
+    iDynTree::KinDynComputations kinDynTree;
+
+
+    // Before calling loadRobotModel, isValid should return false
+    REQUIRE(!kinDynTree.isValid());
+    REQUIRE(!kinDynFor.isValid());
+    REQUIRE(!kinDynForEigen.isValid());
+
+    REQUIRE(kinDynTree.loadRobotModel(idynmodel));
+    bool okLoad = kinDynFor.loadRobotModel(idynmodel);
+    REQUIRE(okLoad);
+    okLoad = kinDynForEigen.loadRobotModel(idynmodel);
+    REQUIRE(okLoad);
+
+
+    // Note: this benchmarks always re-set the state and benchmark a given method, and are a bit
+    // "artificial" in the sense that in typical workload, setRobotState is only called once,
+    // and many methods are called after, tipically reusing cache
+    // Anyhow, it is a good indicator for how fast computing the quantities related to each method is
+    BENCHMARK_ADVANCED("getWorldTransform\niDynTree")(Catch::Benchmark::Chronometer meter) {
+        setRandomState(kinDynTree);
+        iDynTree::FrameIndex randomFrameIndex = rand() % kinDynTree.model().getNrOfFrames();
+
+        meter.measure([&] {
+            auto ret =  kinDynTree.getWorldTransform(randomFrameIndex);
+        });
+    };
+
+    BENCHMARK_ADVANCED("getWorldTransform\niDynFor (iDynTree interface)")(Catch::Benchmark::Chronometer meter) {
+        setRandomState(kinDynFor);
+        iDynTree::FrameIndex randomFrameIndex = rand() % kinDynFor.model().getNrOfFrames();
+        meter.measure([&] { return kinDynFor.getWorldTransform(randomFrameIndex); });
+    };
+
+    BENCHMARK_ADVANCED("getWorldTransform\niDynFor (Eigen interface)")(Catch::Benchmark::Chronometer meter) {
+        setRandomState(kinDynForEigen);
+        iDynTree::FrameIndex randomFrameIndex = rand() % kinDynForEigen.model().getNrOfFrames();
+        iDynFor::KinDynComputationsTpl<double, 0, pinocchio::JointCollectionDefaultTpl>::SE3s result;
+        meter.measure([&] { return kinDynForEigen.getWorldTransform(randomFrameIndex, result); });
+    };
+
+    BENCHMARK_ADVANCED("getFrameVel\niDynTree")(Catch::Benchmark::Chronometer meter) {
+        setRandomState(kinDynTree);
+        iDynTree::FrameIndex randomFrameIndex = rand() % kinDynTree.model().getNrOfFrames();
+        Eigen::Matrix<double, 6, 1> ret_twist;
+        meter.measure([&] { return kinDynTree.getFrameVel(randomFrameIndex, ret_twist); });
+    };
+
+    BENCHMARK_ADVANCED("getFrameVel\niDynFor (iDynTree interface)")(Catch::Benchmark::Chronometer meter) {
+        setRandomState(kinDynFor);
+        iDynTree::FrameIndex randomFrameIndex = rand() % kinDynFor.model().getNrOfFrames();
+        Eigen::Matrix<double, 6, 1> ret_twist;
+        meter.measure([&] { return kinDynFor.getFrameVel(randomFrameIndex, ret_twist); });
+    };
+
+    BENCHMARK_ADVANCED("getFrameVel\niDynFor (Eigen interface)")(Catch::Benchmark::Chronometer meter) {
+        setRandomState(kinDynForEigen);
+        iDynTree::FrameIndex randomFrameIndex = rand() % kinDynForEigen.model().getNrOfFrames();
+        iDynFor::KinDynComputationsTpl<double, 0, pinocchio::JointCollectionDefaultTpl>::Vector6s res_vel;
+        meter.measure([&] { return kinDynForEigen.getFrameVel(randomFrameIndex, res_vel); });
+    };
+
+    BENCHMARK_ADVANCED("getFrameFreeFloatingJacobian\niDynTree")(Catch::Benchmark::Chronometer meter) {
+        setRandomState(kinDynTree);
+        iDynTree::FrameIndex randomFrameIndex = rand() % kinDynTree.model().getNrOfFrames();
+        Eigen::MatrixXd jacobian(6, 6+kinDynTree.model().getNrOfDOFs());
+        meter.measure([&] { return kinDynTree.getFrameFreeFloatingJacobian(
+            randomFrameIndex, iDynTree::make_matrix_view(jacobian)); });
+    };
+
+    BENCHMARK_ADVANCED("getFrameFreeFloatingJacobian\niDynFor (iDynTree interface)")(Catch::Benchmark::Chronometer meter) {
+        setRandomState(kinDynFor);
+        iDynTree::FrameIndex randomFrameIndex = rand() % kinDynFor.model().getNrOfFrames();
+        Eigen::MatrixXd jacobian(6, 6+kinDynFor.model().getNrOfDOFs());
+        meter.measure([&] { return kinDynFor.getFrameFreeFloatingJacobian(
+            randomFrameIndex, iDynTree::make_matrix_view(jacobian)); });
+    };
+
+    BENCHMARK_ADVANCED("getFrameFreeFloatingJacobian\niDynFor (Eigen interface)")(Catch::Benchmark::Chronometer meter) {
+        setRandomState(kinDynFor);
+        iDynTree::FrameIndex randomFrameIndex = rand() % kinDynFor.model().getNrOfFrames();
+        Eigen::MatrixXd jacobian(6, 6+kinDynFor.model().getNrOfDOFs());
+        meter.measure([&] { return kinDynFor.getFrameFreeFloatingJacobian(
+            randomFrameIndex, iDynTree::make_matrix_view(jacobian)); });
+    };
+
+}


### PR DESCRIPTION
See https://github.com/catchorg/Catch2/blob/devel/docs/benchmarks.md for details on Catch2 functionality related to benchmarks. I just run benchmarks on my WSL2 system and on GitHub Actions, so the results are not super accurated, but anyhow it already show that iDynFor are faster than iDynTree equivalent methods:

~~~
3: -------------------------------------------------------------------------------
3: KinDynComputations Benchmarks
3: -------------------------------------------------------------------------------
3: /home/runner/work/idynfor/idynfor/test/KinDynComputationsBenchmark.cpp:68
3: ...............................................................................
3: 
3: benchmark name                       samples       iterations    estimated
3:                                      mean          low mean      high mean
3:                                      std dev       low std dev   high std dev
3: -------------------------------------------------------------------------------
3: getWorldTransform                                                              
3: iDynTree                                       100         17438    55.8016 ms 
3:                                         59.2199 ns    52.0256 ns    68.1416 ns 
3:                                         40.6848 ns    36.4716 ns    43.5878 ns 
3:                                                                                
3: getWorldTransform                                                              
3: iDynFor (iDynTree interface)                   100         14496    56.5344 ms 
3:                                         39.7789 ns    39.7156 ns    39.8705 ns 
3:                                        0.384027 ns   0.287275 ns   0.542271 ns 
3:                                                                                
3: getWorldTransform                                                              
3: iDynFor (Eigen interface)                      100         26287    55.2027 ms 
3:                                         21.9467 ns    21.7752 ns    22.3273 ns 
3:                                         1.27647 ns   0.755716 ns    2.02319 ns 
3:                                                                                
3: getFrameVel                                                                    
3: iDynTree                                       100          2220     57.054 ms 
3:                                         207.354 ns    200.517 ns    214.949 ns 
3:                                         36.7192 ns    33.3499 ns    38.9457 ns 
3:                                                                                
3: getFrameVel                                                                    
3: iDynFor (iDynTree interface)                   100         15955    55.8425 ms 
3:                                         36.2294 ns    36.1419 ns    36.4054 ns 
3:                                         0.60659 ns   0.309171 ns       1.03 ns 
3:                                                                                
3: getFrameVel                                                                    
3: iDynFor (Eigen interface)                      100         47492    56.9904 ms 
3:                                          12.102 ns    12.0811 ns    12.1406 ns 
3:                                        0.140552 ns  0.0806971 ns   0.209452 ns 
3:                                                                                
3: getFrameFreeFloatingJacobian                                                   
3: iDynTree                                       100          1050     57.225 ms 
3:                                         510.948 ns    499.747 ns    521.444 ns 
3:                                          55.274 ns    50.0253 ns    61.1757 ns 
3:                                                                                
3: getFrameFreeFloatingJacobian                                                   
3: iDynFor (iDynTree interface)                   100          1601    57.1557 ms 
3:                                         391.869 ns    376.903 ns    406.484 ns 
3:                                          75.353 ns    67.7116 ns    83.7628 ns 
3:                                                                                
3: getFrameFreeFloatingJacobian                                                   
3: iDynFor (Eigen interface)                      100          1304    57.2456 ms 
3:                                         386.207 ns     370.36 ns    401.349 ns 
3:                                         78.5334 ns    71.4539 ns    86.6201 ns 
~~~

To run the benchmark locally, just run `ctest -VV -R Benchmark` .

By the way, there is something fishy in the slow result of iDynTree's `getFrameVel`, but investigating this is out of the scope of this PR.

